### PR TITLE
fix: 제목 검색 개선

### DIFF
--- a/apps/algogo/src/problems-v2/problems-v2.service.ts
+++ b/apps/algogo/src/problems-v2/problems-v2.service.ts
@@ -10,41 +10,7 @@ export class ProblemsV2Service {
   constructor(private readonly problemsV2Repository: ProblemsV2Repository) {}
 
   async getProblemsSummary(dto: InquiryProblemsSummaryDto) {
-    const MYSQL_FULLTEXT_DELIMITERS = [
-      ' ',
-      ',',
-      '.',
-      ':',
-      ';',
-      '!',
-      '?',
-      '@',
-      '#',
-      '$',
-      '%',
-      '^',
-      '&',
-      '*',
-      '(',
-      ')',
-      '-',
-      '+',
-      '=',
-      '<',
-      '>',
-      '/',
-      '\\',
-      '|',
-      '[',
-      ']',
-      '{',
-      '}',
-      '~',
-      '`',
-      "'",
-      '"',
-      '_',
-    ];
+    const MYSQL_FULLTEXT_DELIMITERS = ['+', '-', '<', '>', '@', '~', '*'];
 
     const hasTitle = !!dto.title;
     const hasSpecial = MYSQL_FULLTEXT_DELIMITERS.some((delimiter) =>


### PR DESCRIPTION
1. 일부 특수문자만 제외하도록 함
2. 일치하는 문자열만 가져오기 위해 내부적으로 includes로 포함되는 문자열을 정확히 필터링하고 페이징도 db가아닌 직접 페이징 하도록 수정함