### PR TITLE
[ALGOGO-30] fix: 에러 로깅 시 민감 헤더(authorization, cookie) 마스킹

### DIFF
--- a/src/filters/all-exceptions.filter.ts
+++ b/src/filters/all-exceptions.filter.ts
@@ -61,13 +61,18 @@ export class AllExceptionsFilter implements ExceptionFilter {
       statusCode === HttpStatus.INTERNAL_SERVER_ERROR ||
       process.env.NODE_ENV === 'development'
     ) {
+      const sanitizedHeaders = {
+        ...request.headers,
+        authorization: '[REDACTED]',
+        cookie: '[REDACTED]',
+      };
       this.logger.error(`INTERNAL_SERVER_ERROR`, {
         ip: request.ip,
         url: request.url,
         exception: exception instanceof Error ? exception.toString() : String(exception),
         stackTrace: process.env.NODE_ENV === 'development' ? stackTrace : '',
         errorMessage,
-        headers: request.headers,
+        headers: sanitizedHeaders,
       });
     }
 


### PR DESCRIPTION
## 작업 내용
- [x] `all-exceptions.filter.ts`에서 에러 로깅 시 `request.headers`를 그대로 출력하던 부분 수정
- [x] `authorization`, `cookie` 헤더를 `[REDACTED]`로 마스킹한 `sanitizedHeaders` 사용

## 테스트
- [x] 빌드 정상 확인

## 관련 이슈
- ALGOGO-30