### PR TITLE
[ALGOGO-32] fix: SQL injection 취약점 수정 (Prisma.raw → Prisma.sql 태그드 템플릿)

### DIFF
--- a/src/problems-v2/problems-v2.repository.ts
+++ b/src/problems-v2/problems-v2.repository.ts
@@ -61,20 +61,20 @@ export class ProblemsV2Repository {
   ) {
     const { pageNo, pageSize, sort, levelList, typeList, title, states } = dto;
 
-    const filters: string[] = [];
+    const filters: Prisma.Sql[] = [];
 
     if (levelList?.length) {
       filters.push(
-        `p.PROBLEM_V2_LEVEL IN (${levelList.map(Number).join(',')})`,
+        Prisma.sql`p.PROBLEM_V2_LEVEL IN (${Prisma.join(levelList.map(Number))})`,
       );
     }
 
     if (typeList?.length) {
-      filters.push(`
+      filters.push(Prisma.sql`
         EXISTS (
           SELECT 1 FROM PROBLEM_V2_TYPE t
           WHERE t.PROBLEM_V2_UUID = p.PROBLEM_V2_UUID
-          AND t.name IN (${typeList.map((v) => `'${v}'`).join(',')})
+          AND t.name IN (${Prisma.join(typeList)})
         )
       `);
     }
@@ -87,64 +87,75 @@ export class ProblemsV2Repository {
 
       if (hasNoneState && otherStates.length > 0) {
         // NONE과 다른 상태들이 모두 포함된 경우
-        filters.push(`
+        filters.push(Prisma.sql`
           (NOT EXISTS (
             SELECT 1 FROM USER_PROBLEM_STATE ups2
             WHERE ups2.PROBLEM_UUID = p.PROBLEM_V2_UUID
-            AND ups2.USER_UUID = '${dto.userUuid}'
+            AND ups2.USER_UUID = ${dto.userUuid}
           ) OR EXISTS (
             SELECT 1 FROM USER_PROBLEM_STATE ups2
             WHERE ups2.PROBLEM_UUID = p.PROBLEM_V2_UUID
-            AND ups2.USER_UUID = '${dto.userUuid}'
-            AND ups2.STATE IN (${otherStates.map((state) => `'${state}'`).join(',')})
+            AND ups2.USER_UUID = ${dto.userUuid}
+            AND ups2.STATE IN (${Prisma.join(otherStates)})
           ))
         `);
       } else if (hasNoneState) {
         // NONE만 포함된 경우 (상태가 없는 문제들)
-        filters.push(`
+        filters.push(Prisma.sql`
           NOT EXISTS (
             SELECT 1 FROM USER_PROBLEM_STATE ups2
             WHERE ups2.PROBLEM_UUID = p.PROBLEM_V2_UUID
-            AND ups2.USER_UUID = '${dto.userUuid}'
+            AND ups2.USER_UUID = ${dto.userUuid}
           )
         `);
       } else {
         // 다른 상태들만 포함된 경우
-        filters.push(`
+        filters.push(Prisma.sql`
           EXISTS (
             SELECT 1 FROM USER_PROBLEM_STATE ups2
             WHERE ups2.PROBLEM_UUID = p.PROBLEM_V2_UUID
-            AND ups2.USER_UUID = '${dto.userUuid}'
-            AND ups2.STATE IN (${otherStates.map((state) => `'${state}'`).join(',')})
+            AND ups2.USER_UUID = ${dto.userUuid}
+            AND ups2.STATE IN (${Prisma.join(otherStates)})
           )
         `);
       }
     }
 
-    const whereClause = filters.length ? `AND ${filters.join(' AND ')}` : '';
+    const whereClause =
+      filters.length > 0
+        ? Prisma.sql`AND ${Prisma.join(filters, ' AND ')}`
+        : Prisma.empty;
 
     const orderClause = (() => {
       switch (sort) {
         case PROBLEM_SORT_MAP.ANSWER_RATE_DESC:
-          return 'ORDER BY p.PROBLEM_V2_ANSWER_RATE DESC';
+          return Prisma.sql`ORDER BY p.PROBLEM_V2_ANSWER_RATE DESC`;
         case PROBLEM_SORT_MAP.ANSWER_RATE_ASC:
-          return 'ORDER BY p.PROBLEM_V2_ANSWER_RATE ASC';
+          return Prisma.sql`ORDER BY p.PROBLEM_V2_ANSWER_RATE ASC`;
         case PROBLEM_SORT_MAP.LEVEL_ASC:
-          return 'ORDER BY p.PROBLEM_V2_LEVEL ASC';
+          return Prisma.sql`ORDER BY p.PROBLEM_V2_LEVEL ASC`;
         case PROBLEM_SORT_MAP.LEVEL_DESC:
-          return 'ORDER BY p.PROBLEM_V2_LEVEL DESC';
+          return Prisma.sql`ORDER BY p.PROBLEM_V2_LEVEL DESC`;
         case PROBLEM_SORT_MAP.SUBMIT_COUNT_ASC:
-          return 'ORDER BY p.PROBLEM_V2_SUBMIT_COUNT ASC';
+          return Prisma.sql`ORDER BY p.PROBLEM_V2_SUBMIT_COUNT ASC`;
         case PROBLEM_SORT_MAP.SUBMIT_COUNT_DESC:
-          return 'ORDER BY p.PROBLEM_V2_SUBMIT_COUNT DESC';
+          return Prisma.sql`ORDER BY p.PROBLEM_V2_SUBMIT_COUNT DESC`;
         case PROBLEM_SORT_MAP.TITLE_ASC:
-          return 'ORDER BY p.PROBLEM_V2_TITLE ASC';
+          return Prisma.sql`ORDER BY p.PROBLEM_V2_TITLE ASC`;
         case PROBLEM_SORT_MAP.TITLE_DESC:
-          return 'ORDER BY p.PROBLEM_V2_TITLE DESC';
+          return Prisma.sql`ORDER BY p.PROBLEM_V2_TITLE DESC`;
         default:
-          return 'ORDER BY p.PROBLEM_V2_NO ASC';
+          return Prisma.sql`ORDER BY p.PROBLEM_V2_NO ASC`;
       }
     })();
+
+    const stateSelectClause = dto.userUuid
+      ? Prisma.sql`COALESCE(ups.STATE, 'NONE') AS state`
+      : Prisma.sql`'NONE' AS state`;
+
+    const joinClause = dto.userUuid
+      ? Prisma.sql`LEFT JOIN USER_PROBLEM_STATE ups ON ups.PROBLEM_UUID = p.PROBLEM_V2_UUID AND ups.USER_UUID = ${dto.userUuid}`
+      : Prisma.empty;
 
     const rawList = await this.prismaService.$queryRaw<ProblemSummaryDto[]>(
       Prisma.sql`
@@ -160,20 +171,12 @@ export class ProblemsV2Repository {
           p.PROBLEM_V2_SOURCE AS source,
           p.PROBLEM_V2_SOURCE_ID AS sourceId,
           p.PROBLEM_V2_SOURCE_URL AS sourceUrl,
-          ${Prisma.raw(
-            dto.userUuid
-              ? `COALESCE(ups.STATE, 'NONE') AS state`
-              : `'NONE' AS state`,
-          )}
+          ${stateSelectClause}
         FROM PROBLEM_V2 p
-        ${Prisma.raw(
-          dto.userUuid
-            ? `LEFT JOIN USER_PROBLEM_STATE ups ON ups.PROBLEM_UUID = p.PROBLEM_V2_UUID AND ups.USER_UUID = '${dto.userUuid}'`
-            : '',
-        )}
+        ${joinClause}
         WHERE MATCH(p.PROBLEM_V2_TITLE) AGAINST(${title} IN BOOLEAN MODE)
-        ${Prisma.raw(whereClause)}
-        ${Prisma.raw(orderClause)}
+        ${whereClause}
+        ${orderClause}
         LIMIT 1000;
       `,
     );


### PR DESCRIPTION
## 작업 내용
- [x] `problems-v2.repository`에서 `Prisma.raw`로 직접 문자열 보간하던 쿼리를 `Prisma.sql` 태그드 템플릿으로 교체
- [x] SQL Injection 취약점 제거

## 테스트
- [x] 빌드 정상 확인

## 관련 이슈
- ALGOGO-32