### PR TITLE
[ALGOGO-33] refactor: NestJS 빌트인 예외를 커스텀 예외 계층으로 교체

### DIFF
--- a/src/common/errors/CustomBadRequestException.ts
+++ b/src/common/errors/CustomBadRequestException.ts
@@ -1,0 +1,9 @@
+import { HttpStatus } from '@nestjs/common';
+import { CustomHttpException } from './CustomHttpException';
+import { CustomError } from '../types/error.type';
+
+export class CustomBadRequestException extends CustomHttpException {
+  constructor(error: CustomError) {
+    super(error, HttpStatus.BAD_REQUEST);
+  }
+}

--- a/src/problems-collect/errors/ImageUploadFailedException.ts
+++ b/src/problems-collect/errors/ImageUploadFailedException.ts
@@ -1,0 +1,10 @@
+import { CustomBadRequestException } from '../../common/errors/CustomBadRequestException';
+
+export class ImageUploadFailedException extends CustomBadRequestException {
+  constructor() {
+    super({
+      message: '이미지 업로드에 실패했습니다.',
+      code: 'IMAGE_UPLOAD_FAILED',
+    });
+  }
+}

--- a/src/problems-collect/problems-collect.service.ts
+++ b/src/problems-collect/problems-collect.service.ts
@@ -1,5 +1,6 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { ProblemSiteNotFoundException } from './errors/ProblemSiteNotFoundException';
+import { ImageUploadFailedException } from './errors/ImageUploadFailedException';
 import { ProblemsCollectRepository } from './problems-collect.repository';
 import { RedisService } from '../redis/redis.service';
 import { CrawlerService } from '../crawler/crawler.service';
@@ -63,7 +64,7 @@ export class ProblemsCollectService {
           const s3Result = await this.s3Service.upload(s3Key, webp);
 
           if (!s3Result) {
-            throw new BadRequestException('이미지 업로드 오류');
+            throw new ImageUploadFailedException();
           }
 
           return {

--- a/src/problems/problems.service.ts
+++ b/src/problems/problems.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { ProblemNotFoundException } from '../common/errors/problem/ProblemNotFoundException';
 import { ProblemsRepository } from './problems.repository';
 import { ProblemType } from '../common/types/problem.type';
 import { ResponseProblemDto } from './dto/ResponseProblemDto';
@@ -53,7 +54,7 @@ export class ProblemsService {
       const problem = await this.problemsRepository.getProblem(uuid);
 
       if (!problem) {
-        throw new NotFoundException('문제를 찾을 수 없습니다.');
+        throw new ProblemNotFoundException();
       }
 
       return {

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,7 +1,6 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { UsersRepository } from './users.repository';
 
-import { USER_NOT_FOUND_MESSAGE } from './constants';
 import { OAuthProvider } from '../common/types/oauth.type';
 import { UserInactiveException } from '../common/errors/user/UserInactiveException';
 import { UserNotFoundException } from '../common/errors/user/UserNotFoundException';
@@ -24,7 +23,7 @@ export class UsersService {
     });
 
     if (!user) {
-      throw new NotFoundException(USER_NOT_FOUND_MESSAGE);
+      throw new UserNotFoundException();
     }
 
     return {


### PR DESCRIPTION
## 작업 내용
- [x] `users.service.ts`: `NotFoundException` → `UserNotFoundException`
- [x] `problems.service.ts`: `NotFoundException` → `ProblemNotFoundException`
- [x] `problems-collect.service.ts`: `BadRequestException` → `ImageUploadFailedException`
- [x] `CustomBadRequestException` (400) 베이스 클래스 추가
- [x] `ImageUploadFailedException` 도메인 예외 추가

## 테스트
- [x] TypeScript 컴파일 정상 확인 (기존 axios 타입 에러 외 신규 에러 없음)

## 관련 이슈
- ALGOGO-33