### PR TITLE
[ALGOGO-34] refactor: Controller 쿠키 설정 로직을 TokenCookieService로 추출

### DIFF
--- a/src/auth-v2/auth-v2.controller.ts
+++ b/src/auth-v2/auth-v2.controller.ts
@@ -19,11 +19,9 @@ import { ApiGlobalErrorResponses } from '../common/decorators/swagger/ApiGlobalE
 import { RequestMetadata as Metadata } from '../common/types/request.type';
 import { RequestMetadata } from '../common/decorators/contexts/request-metadata.decorator';
 import { Request, Response } from 'express';
-import { Inject } from '@nestjs/common';
-import JwtConfig from '../config/jwtConfig';
-import { ConfigType } from '@nestjs/config';
-import { User } from 'src/common/decorators/contexts/user.decorator';
-import { AuthGuard } from 'src/auth-guard/auth.guard';
+import { TokenCookieService } from '../jwt/token-cookie.service';
+import { User } from '../common/decorators/contexts/user.decorator';
+import { AuthGuard } from '../auth-guard/auth.guard';
 
 @ApiTags('Auth V2')
 @ApiBearerAuth('Authorization')
@@ -32,8 +30,7 @@ import { AuthGuard } from 'src/auth-guard/auth.guard';
 export class AuthV2Controller {
   constructor(
     private readonly authV2Service: AuthV2Service,
-    @Inject(JwtConfig.KEY)
-    private readonly jwtConfig: ConfigType<typeof JwtConfig>,
+    private readonly tokenCookieService: TokenCookieService,
   ) {}
 
   @ApiOperation({
@@ -72,19 +69,7 @@ export class AuthV2Controller {
       userAgent: metadata.userAgent,
     });
 
-    res.cookie('access_token', accessToken, {
-      httpOnly: process.env.NODE_ENV !== 'development', // 개발환경에서는 접근 허용
-      secure: process.env.NODE_ENV !== 'development',
-      sameSite: process.env.NODE_ENV !== 'development' ? 'strict' : 'lax', // 개발환경에서는 lax
-      maxAge: this.jwtConfig.jwtAccessTokenExpiresIn * 1000,
-    });
-
-    res.cookie('refresh_token', refreshToken, {
-      httpOnly: process.env.NODE_ENV !== 'development', // 개발환경에서는 접근 허용
-      secure: process.env.NODE_ENV !== 'development',
-      sameSite: process.env.NODE_ENV !== 'development' ? 'strict' : 'lax', // 개발환경에서는 lax
-      maxAge: this.jwtConfig.jwtRefreshTokenExpiresIn * 1000,
-    });
+    this.tokenCookieService.setAuthCookies(res, { accessToken, refreshToken });
 
     return {
       accessToken,
@@ -115,8 +100,7 @@ export class AuthV2Controller {
       refreshToken,
     });
 
-    res.clearCookie('access_token');
-    res.clearCookie('refresh_token');
+    this.tokenCookieService.clearAuthCookies(res);
 
     return;
   }

--- a/src/jwt/jwt.module.ts
+++ b/src/jwt/jwt.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { JwtService } from './jwt.service';
 import { JwtModule as NestJwtModule } from '@nestjs/jwt';
+import { TokenCookieService } from './token-cookie.service';
 
 @Module({
   imports: [NestJwtModule.register({})],
-  providers: [JwtService],
-  exports: [JwtService],
+  providers: [JwtService, TokenCookieService],
+  exports: [JwtService, TokenCookieService],
 })
 export class JwtModule {}

--- a/src/jwt/token-cookie.service.ts
+++ b/src/jwt/token-cookie.service.ts
@@ -1,0 +1,40 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { ConfigType } from '@nestjs/config';
+import { Response } from 'express';
+import JwtConfig from '../config/jwtConfig';
+
+@Injectable()
+export class TokenCookieService {
+  private readonly isProduction: boolean;
+
+  constructor(
+    @Inject(JwtConfig.KEY)
+    private readonly jwtConfig: ConfigType<typeof JwtConfig>,
+  ) {
+    this.isProduction = process.env.NODE_ENV !== 'development';
+  }
+
+  setAuthCookies(
+    res: Response,
+    tokens: { accessToken: string; refreshToken: string },
+  ) {
+    res.cookie('access_token', tokens.accessToken, {
+      httpOnly: this.isProduction,
+      secure: this.isProduction,
+      sameSite: this.isProduction ? 'strict' : 'lax',
+      maxAge: this.jwtConfig.jwtAccessTokenExpiresIn * 1000,
+    });
+
+    res.cookie('refresh_token', tokens.refreshToken, {
+      httpOnly: this.isProduction,
+      secure: this.isProduction,
+      sameSite: this.isProduction ? 'strict' : 'lax',
+      maxAge: this.jwtConfig.jwtRefreshTokenExpiresIn * 1000,
+    });
+  }
+
+  clearAuthCookies(res: Response) {
+    res.clearCookie('access_token');
+    res.clearCookie('refresh_token');
+  }
+}

--- a/src/oauth-v2/oauth.api.v2.controller.ts
+++ b/src/oauth-v2/oauth.api.v2.controller.ts
@@ -4,7 +4,6 @@ import {
   Post,
   Res,
   UseGuards,
-  Inject,
 } from '@nestjs/common';
 import { DynamicOAuthGuard } from './dynamic-oauth.guard';
 import { OAuthProvider, OAuthRequestUser } from '../common/types/oauth.type';
@@ -16,15 +15,13 @@ import { OAuth } from '../common/decorators/contexts/oauth.decorator';
 import { RequestMetadata } from '../common/decorators/contexts/request-metadata.decorator';
 import { RequestMetadata as Metadata } from '../common/types/request.type';
 import { Response } from 'express';
-import JwtConfig from '../config/jwtConfig';
-import { ConfigType } from '@nestjs/config';
+import { TokenCookieService } from '../jwt/token-cookie.service';
 
 @Controller('api/v2/oauth')
 export class OauthApiV2Controller {
   constructor(
     private readonly oauthV2Service: OauthV2Service,
-    @Inject(JwtConfig.KEY)
-    private readonly jwtConfig: ConfigType<typeof JwtConfig>,
+    private readonly tokenCookieService: TokenCookieService,
   ) {}
 
   @Post('/:provider')
@@ -41,19 +38,7 @@ export class OauthApiV2Controller {
         userAgent: metadata.userAgent,
       });
 
-    res.cookie('access_token', accessToken, {
-      httpOnly: process.env.NODE_ENV !== 'development', // 개발환경에서는 접근 허용
-      secure: process.env.NODE_ENV !== 'development',
-      sameSite: process.env.NODE_ENV !== 'development' ? 'strict' : 'lax', // 개발환경에서는 lax
-      maxAge: this.jwtConfig.jwtAccessTokenExpiresIn * 1000,
-    });
-
-    res.cookie('refresh_token', refreshToken, {
-      httpOnly: process.env.NODE_ENV !== 'development', // 개발환경에서는 접근 허용
-      secure: process.env.NODE_ENV !== 'development',
-      sameSite: process.env.NODE_ENV !== 'development' ? 'strict' : 'lax', // 개발환경에서는 lax
-      maxAge: this.jwtConfig.jwtRefreshTokenExpiresIn * 1000,
-    });
+    this.tokenCookieService.setAuthCookies(res, { accessToken, refreshToken });
 
     return {
       accessToken,


### PR DESCRIPTION
## 작업 내용
- [x] `TokenCookieService` 생성 (jwt 모듈에 등록/export)
- [x] `auth-v2.controller.ts`: 쿠키 설정 로직 → `tokenCookieService.setAuthCookies()` 위임
- [x] `oauth.api.v2.controller.ts`: 동일하게 위임
- [x] 로그아웃 시 `clearAuthCookies()` 사용

## 테스트
- [x] TypeScript 컴파일 정상 확인

## 관련 이슈
- ALGOGO-34