### PR TITLE
[ALGOGO-35] refactor: process.env 직접 접근을 ConfigModule로 통일

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -41,6 +41,7 @@ import encryptConfig from './config/encryptConfig';
 import bullmqConfig from './config/bullmqConfig';
 import wsConfig from './config/wsConfig';
 import LoggerConfig from './config/LoggerConfig';
+import appConfig from './config/appConfig';
 import { CacheModule } from '@nestjs/cache-manager';
 import { RequestMetadataMiddleware } from './middlewares/RequestMetadataMiddleware';
 import { AuthGuardModule } from './auth-guard/auth-guard.module';
@@ -67,6 +68,7 @@ import { createKeyv } from '@keyv/redis';
     ConfigModule.forRoot({
       envFilePath: [`.${process.env.NODE_ENV ?? 'production'}.env`],
       load: [
+        appConfig,
         crawlerConfig,
         s3Config,
         googleOAuthConfig,

--- a/src/config/appConfig.ts
+++ b/src/config/appConfig.ts
@@ -1,0 +1,7 @@
+import { registerAs } from '@nestjs/config';
+
+export default registerAs('appConfig', () => ({
+  nodeEnv: process.env.NODE_ENV ?? 'production',
+  isDevelopment: process.env.NODE_ENV === 'development',
+  frontendUrl: process.env.FRONTEND_URL ?? '',
+}));

--- a/src/config/validationSchema.ts
+++ b/src/config/validationSchema.ts
@@ -1,6 +1,10 @@
 import * as Joi from 'joi';
 
 export const validationSchema = Joi.object({
+  NODE_ENV: Joi.string()
+    .valid('development', 'production', 'test')
+    .default('production'),
+  FRONTEND_URL: Joi.string().default(''),
   DATABASE_URL: Joi.string().required(),
   CRAWLER_URL: Joi.string().required(),
   SERVER_PORT: Joi.string().required(),

--- a/src/filters/all-exceptions.filter.ts
+++ b/src/filters/all-exceptions.filter.ts
@@ -8,18 +8,26 @@ import {
   Injectable,
 } from '@nestjs/common';
 import { HttpAdapterHost } from '@nestjs/core';
+import { ConfigType } from '@nestjs/config';
 import { CustomHttpException } from '../common/errors/CustomHttpException';
 import { Logger } from 'winston';
 import { CustomError } from '../common/types/error.type';
+import appConfig from '../config/appConfig';
 
 @Injectable()
 @Catch()
 export class AllExceptionsFilter implements ExceptionFilter {
+  private readonly isDevelopment: boolean;
+
   constructor(
     @Inject('winston')
     private readonly logger: Logger,
     private readonly httpAdapterHost: HttpAdapterHost,
-  ) {}
+    @Inject(appConfig.KEY)
+    private readonly appCfg: ConfigType<typeof appConfig>,
+  ) {
+    this.isDevelopment = appCfg.isDevelopment;
+  }
 
   catch(exception: unknown, host: ArgumentsHost): void {
     const { httpAdapter } = this.httpAdapterHost;
@@ -27,7 +35,7 @@ export class AllExceptionsFilter implements ExceptionFilter {
     const request = ctx.getRequest();
     const response = ctx.getResponse();
 
-    const isDevelopment = process.env.NODE_ENV === 'development';
+    const isDevelopment = this.isDevelopment;
 
     const statusCode =
       exception instanceof HttpException
@@ -59,7 +67,7 @@ export class AllExceptionsFilter implements ExceptionFilter {
 
     if (
       statusCode === HttpStatus.INTERNAL_SERVER_ERROR ||
-      process.env.NODE_ENV === 'development'
+      isDevelopment
     ) {
       const sanitizedHeaders = {
         ...request.headers,
@@ -70,7 +78,7 @@ export class AllExceptionsFilter implements ExceptionFilter {
         ip: request.ip,
         url: request.url,
         exception: exception instanceof Error ? exception.toString() : String(exception),
-        stackTrace: process.env.NODE_ENV === 'development' ? stackTrace : '',
+        stackTrace: isDevelopment ? stackTrace : '',
         errorMessage,
         headers: sanitizedHeaders,
       });

--- a/src/oauth-v2/oauth-exception.filter.ts
+++ b/src/oauth-v2/oauth-exception.filter.ts
@@ -2,16 +2,23 @@ import {
   ExceptionFilter,
   Catch,
   ArgumentsHost,
+  Inject,
   Injectable,
   HttpException,
 } from '@nestjs/common';
+import { ConfigType } from '@nestjs/config';
 import { Response } from 'express';
 import { CustomLogger } from '../logger/custom-logger';
+import appConfig from '../config/appConfig';
 
 @Injectable()
 @Catch()
 export class OAuthExceptionFilter implements ExceptionFilter {
-  constructor(private readonly logger: CustomLogger) {}
+  constructor(
+    private readonly logger: CustomLogger,
+    @Inject(appConfig.KEY)
+    private readonly appCfg: ConfigType<typeof appConfig>,
+  ) {}
 
   catch(exception: unknown, host: ArgumentsHost) {
     this.logger.error('oauth exception', { exception: String(exception) });
@@ -23,12 +30,12 @@ export class OAuthExceptionFilter implements ExceptionFilter {
         ? exception.message || '정의되지 않은 오류가 발생하였습니다'
         : '정의되지 않은 오류가 발생하였습니다';
 
+    const baseUrl = this.appCfg.isDevelopment
+      ? this.appCfg.frontendUrl
+      : '';
+
     response
       .status(302)
-      .redirect(
-        process.env.NODE_ENV === 'development'
-          ? `http://localhost:5173/error?message=${errorMessage}`
-          : `/error?message=${errorMessage}`,
-      );
+      .redirect(`${baseUrl}/error?message=${errorMessage}`);
   }
 }

--- a/src/prisma/prisma.service.ts
+++ b/src/prisma/prisma.service.ts
@@ -1,19 +1,22 @@
-import { Injectable, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
+import { Inject, Injectable, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
+import { ConfigType } from '@nestjs/config';
 import { PrismaClient } from '@prisma/client';
+import appConfig from '../config/appConfig';
 
 @Injectable()
 export class PrismaService
   extends PrismaClient
   implements OnModuleInit, OnModuleDestroy
 {
-  constructor() {
-    if (process.env.NODE_ENV === 'development') {
-      super({
-        log: ['query', 'info', 'warn', 'error'],
-      });
-    } else {
-      super({});
-    }
+  constructor(
+    @Inject(appConfig.KEY)
+    appCfg: ConfigType<typeof appConfig>,
+  ) {
+    super(
+      appCfg.isDevelopment
+        ? { log: ['query', 'info', 'warn', 'error'] }
+        : {},
+    );
   }
   async onModuleInit() {
     await this.$connect();

--- a/src/redis/redis.io.adapter.ts
+++ b/src/redis/redis.io.adapter.ts
@@ -2,14 +2,23 @@ import { IoAdapter } from '@nestjs/platform-socket.io';
 import { ServerOptions } from 'socket.io';
 import { createAdapter } from '@socket.io/redis-adapter';
 import { createClient } from 'redis';
+import { INestApplication } from '@nestjs/common';
+import { ConfigType } from '@nestjs/config';
+import redisConfig from '../config/redisConfig';
 
 export class RedisIoAdapter extends IoAdapter {
   private adapterConstructor!: ReturnType<typeof createAdapter>;
+  private readonly redisCfg: ConfigType<typeof redisConfig>;
+
+  constructor(app: INestApplication) {
+    super(app);
+    this.redisCfg = app.get(redisConfig.KEY);
+  }
 
   async connectToRedis(): Promise<void> {
     const pubClient = createClient({
-      url: `redis://${process.env.REDIS_HOST}:${process.env.REDIS_PORT}`,
-      password: process.env.REDIS_PASSWORD,
+      url: `redis://${this.redisCfg.host}:${this.redisCfg.port}`,
+      password: this.redisCfg.password,
     });
     const subClient = pubClient.duplicate();
 


### PR DESCRIPTION
## 작업 내용
- [x] `appConfig` 생성 (nodeEnv, isDevelopment, frontendUrl)
- [x] `all-exceptions.filter.ts`: `process.env.NODE_ENV` → `appConfig.isDevelopment`
- [x] `oauth-exception.filter.ts`: 하드코딩 localhost URL → `appConfig.frontendUrl`
- [x] `prisma.service.ts`: `process.env.NODE_ENV` → `appConfig.isDevelopment`
- [x] `redis.io.adapter.ts`: `process.env.REDIS_*` → `redisConfig` (app context 주입)
- [x] `validationSchema`에 `NODE_ENV`, `FRONTEND_URL` 추가

## 테스트
- [x] TypeScript 컴파일 정상 확인

## 관련 이슈
- ALGOGO-35