### PR TITLE
[ALGOGO-36] refactor: TypeScript enum을 as const 객체로 전환

### DIFF
--- a/src/problems/dto/RequestProblemSummaryListDto.ts
+++ b/src/problems/dto/RequestProblemSummaryListDto.ts
@@ -1,9 +1,9 @@
-import { IsNumber, IsIn, Min, IsOptional, IsEnum } from 'class-validator';
+import { IsNumber, IsIn, Min, IsOptional } from 'class-validator';
 import { Transform } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
 import { ProblemType } from '../../common/types/problem.type';
-import { ProblemSort } from '../enum/ProblemSortEnum';
-import { PROBLEM_TYPE } from 'src/common/constants/problem.constant';
+import { PROBLEM_SORT, ProblemSort } from '../enum/ProblemSortEnum';
+import { PROBLEM_TYPE } from '../../common/constants/problem.constant';
 
 export class RequestProblemSummaryListDto {
   @Transform(({ value }) => (value !== undefined ? Number(value) : 1))
@@ -62,13 +62,13 @@ export class RequestProblemSummaryListDto {
   typeList?: ProblemType[];
 
   @IsOptional()
-  @IsEnum(ProblemSort)
+  @IsIn(Object.values(PROBLEM_SORT))
   @ApiProperty({
     description: '문제 정렬',
-    default: ProblemSort.DEFAULT,
-    enum: ProblemSort,
+    default: PROBLEM_SORT.DEFAULT,
+    enum: Object.values(PROBLEM_SORT),
     enumName: 'ProblemSort',
     required: false,
   })
-  sort: ProblemSort = ProblemSort.DEFAULT;
+  sort: ProblemSort = PROBLEM_SORT.DEFAULT;
 }

--- a/src/problems/enum/ProblemContentTypeEnum.ts
+++ b/src/problems/enum/ProblemContentTypeEnum.ts
@@ -1,4 +1,7 @@
-export enum ProblemContentType {
-  IMAGE = 'image',
-  TEXT = 'text',
-}
+export const PROBLEM_CONTENT_TYPE = {
+  IMAGE: 'image',
+  TEXT: 'text',
+} as const;
+
+export type ProblemContentType =
+  (typeof PROBLEM_CONTENT_TYPE)[keyof typeof PROBLEM_CONTENT_TYPE];

--- a/src/problems/enum/ProblemSearchFilterEnum.ts
+++ b/src/problems/enum/ProblemSearchFilterEnum.ts
@@ -1,4 +1,7 @@
-export enum ProblemSearchFilter {
-  DEFAULT = 0,
-  TITLE = 1,
-}
+export const PROBLEM_SEARCH_FILTER = {
+  DEFAULT: 0,
+  TITLE: 1,
+} as const;
+
+export type ProblemSearchFilter =
+  (typeof PROBLEM_SEARCH_FILTER)[keyof typeof PROBLEM_SEARCH_FILTER];

--- a/src/problems/enum/ProblemSiteEnum.ts
+++ b/src/problems/enum/ProblemSiteEnum.ts
@@ -1,3 +1,5 @@
-export enum ProblemSite {
-  BOJ = 'BOJ',
-}
+export const PROBLEM_SITE = {
+  BOJ: 'BOJ',
+} as const;
+
+export type ProblemSite = (typeof PROBLEM_SITE)[keyof typeof PROBLEM_SITE];

--- a/src/problems/enum/ProblemSortEnum.ts
+++ b/src/problems/enum/ProblemSortEnum.ts
@@ -1,11 +1,13 @@
-export enum ProblemSort {
-  DEFAULT = 0,
-  TITLE_ASC = 10,
-  TITLE_DESC = 11,
-  LEVEL_ASC = 20,
-  LEVEL_DESC = 21,
-  ANSWER_RATE_ASC = 30,
-  ANSWER_RATE_DESC = 31,
-  SUBMIT_COUNT_ASC = 40,
-  SUBMIT_COUNT_DESC = 41,
-}
+export const PROBLEM_SORT = {
+  DEFAULT: 0,
+  TITLE_ASC: 10,
+  TITLE_DESC: 11,
+  LEVEL_ASC: 20,
+  LEVEL_DESC: 21,
+  ANSWER_RATE_ASC: 30,
+  ANSWER_RATE_DESC: 31,
+  SUBMIT_COUNT_ASC: 40,
+  SUBMIT_COUNT_DESC: 41,
+} as const;
+
+export type ProblemSort = (typeof PROBLEM_SORT)[keyof typeof PROBLEM_SORT];

--- a/src/problems/problems.repository.ts
+++ b/src/problems/problems.repository.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { ProblemType } from '../common/types/problem.type';
-import { ProblemSort } from './enum/ProblemSortEnum';
+import { PROBLEM_SORT, ProblemSort } from './enum/ProblemSortEnum';
 import { Prisma } from '@prisma/client';
 
 @Injectable()
@@ -15,35 +15,35 @@ export class ProblemsRepository {
     | Prisma.ProblemOrderByWithRelationInput[] {
     const orderBy: Prisma.ProblemOrderByWithRelationInput[] = [];
 
-    if (sort === ProblemSort.ANSWER_RATE_ASC) {
+    if (sort === PROBLEM_SORT.ANSWER_RATE_ASC) {
       orderBy.push({
         answerRate: 'asc',
       });
-    } else if (sort === ProblemSort.ANSWER_RATE_DESC) {
+    } else if (sort === PROBLEM_SORT.ANSWER_RATE_DESC) {
       orderBy.push({
         answerRate: 'desc',
       });
-    } else if (sort === ProblemSort.LEVEL_ASC) {
+    } else if (sort === PROBLEM_SORT.LEVEL_ASC) {
       orderBy.push({
         level: 'asc',
       });
-    } else if (sort === ProblemSort.LEVEL_DESC) {
+    } else if (sort === PROBLEM_SORT.LEVEL_DESC) {
       orderBy.push({
         level: 'desc',
       });
-    } else if (sort === ProblemSort.SUBMIT_COUNT_ASC) {
+    } else if (sort === PROBLEM_SORT.SUBMIT_COUNT_ASC) {
       orderBy.push({
         submitCount: 'asc',
       });
-    } else if (sort === ProblemSort.SUBMIT_COUNT_DESC) {
+    } else if (sort === PROBLEM_SORT.SUBMIT_COUNT_DESC) {
       orderBy.push({
         submitCount: 'desc',
       });
-    } else if (sort === ProblemSort.TITLE_ASC) {
+    } else if (sort === PROBLEM_SORT.TITLE_ASC) {
       orderBy.push({
         title: 'asc',
       });
-    } else if (sort === ProblemSort.TITLE_DESC) {
+    } else if (sort === PROBLEM_SORT.TITLE_DESC) {
       orderBy.push({
         title: 'desc',
       });


### PR DESCRIPTION
## 작업 내용
- [x] `ProblemSort` enum → `PROBLEM_SORT` as const 객체 + 타입
- [x] `ProblemSite` enum → `PROBLEM_SITE` as const 객체 + 타입
- [x] `ProblemContentType` enum → `PROBLEM_CONTENT_TYPE` as const 객체 + 타입
- [x] `ProblemSearchFilter` enum → `PROBLEM_SEARCH_FILTER` as const 객체 + 타입
- [x] `problems.repository.ts` 참조 업데이트
- [x] DTO에서 `@IsEnum` → `@IsIn(Object.values())` 변경

## 테스트
- [x] TypeScript 컴파일 정상 확인

## 관련 이슈
- ALGOGO-36