### PR TITLE
[ALGOGO-37] refactor: 코드 품질 개선 (console.log 제거, 매직넘버 상수 추출)

### DIFF
--- a/src/code/code.service.ts
+++ b/src/code/code.service.ts
@@ -12,6 +12,7 @@ import RequestCreateCodeTemplateDto from './dto/RequestCreateCodeTemplateDto';
 import { NotFoundProblemException } from './errors/NotFoundProblemException';
 import { NotFoundProblemCode } from './errors/NotFoundProblemCode';
 import { RedisService } from '../redis/redis.service';
+import { MAX_CODE_TEMPLATE_COUNT } from './constants';
 import RequestUpsertProblemCodeDto from './dto/RequestUpsertProblemCodeDto';
 import { CustomLogger } from '../logger/custom-logger';
 @Injectable()
@@ -82,7 +83,7 @@ export class CodeService {
     const count =
       await this.codeRepository.selectTotalCodeTemplateCount(userUuid);
 
-    if (count >= 10) {
+    if (count >= MAX_CODE_TEMPLATE_COUNT) {
       throw new CodeTemplateLimitExceededException();
     }
 

--- a/src/code/constants.ts
+++ b/src/code/constants.ts
@@ -1,0 +1,1 @@
+export const MAX_CODE_TEMPLATE_COUNT = 10;

--- a/src/common/constants/pagination.constant.ts
+++ b/src/common/constants/pagination.constant.ts
@@ -1,0 +1,4 @@
+export const DEFAULT_PAGE_NO = 1;
+export const DEFAULT_PAGE_SIZE = 10;
+export const ALLOWED_PAGE_SIZES = [10, 20, 50] as const;
+export const FULLTEXT_SEARCH_LIMIT = 1000;

--- a/src/problems-collect/problems-collect.service.ts
+++ b/src/problems-collect/problems-collect.service.ts
@@ -20,7 +20,7 @@ export class ProblemsCollectService {
   ) {}
 
   async collect({ url, userNo }: { url: string; userNo: string }) {
-    console.log(url, userNo);
+    this.logger.debug('collect', { url, userNo });
     throw new Error('Not implemented');
   }
 

--- a/src/problems-v2/dto/inquiry-problems-summary.dto.ts
+++ b/src/problems-v2/dto/inquiry-problems-summary.dto.ts
@@ -6,6 +6,7 @@ import { PROBLEM_TYPE_MAP } from '../constants/problems-type';
 import { PROBLEM_SORT_MAP } from '../constants/problems-sort';
 import { UserProblemState } from '../../common/types/user.type';
 import { USER_PROBLEM_STATE } from '../../common/constants/user.constant';
+import { ALLOWED_PAGE_SIZES, DEFAULT_PAGE_SIZE } from '../../common/constants/pagination.constant';
 
 export class InquiryProblemsSummaryDto {
   @Transform(({ value }) => (value !== undefined ? Number(value) : 1))
@@ -21,15 +22,15 @@ export class InquiryProblemsSummaryDto {
   })
   pageNo?: number = 1;
 
-  @IsIn([10, 20, 50], { message: '10, 20 또는 50 단위로만 조회가 가능합니다.' })
-  @Transform(({ value }) => (value !== undefined ? Number(value) : 10))
+  @IsIn([...ALLOWED_PAGE_SIZES], { message: '10, 20 또는 50 단위로만 조회가 가능합니다.' })
+  @Transform(({ value }) => (value !== undefined ? Number(value) : DEFAULT_PAGE_SIZE))
   @ApiProperty({
     description: '페이지 사이즈',
-    minimum: 10,
-    default: 10,
+    minimum: DEFAULT_PAGE_SIZE,
+    default: DEFAULT_PAGE_SIZE,
     type: Number,
   })
-  pageSize?: number = 10;
+  pageSize?: number = DEFAULT_PAGE_SIZE;
 
   @IsOptional()
   @ApiProperty({

--- a/src/problems-v2/problems-v2.repository.ts
+++ b/src/problems-v2/problems-v2.repository.ts
@@ -6,6 +6,7 @@ import { ProblemSort } from './types/problem.type';
 import { PROBLEM_SORT_MAP } from './constants/problems-sort';
 import { ProblemSummaryDto } from './dto/problem-summary.dto';
 import { USER_PROBLEM_STATE } from '../common/constants/user.constant';
+import { DEFAULT_PAGE_NO, DEFAULT_PAGE_SIZE, FULLTEXT_SEARCH_LIMIT } from '../common/constants/pagination.constant';
 import { UserProblemState } from '../common/types/user.type';
 
 @Injectable()
@@ -177,7 +178,7 @@ export class ProblemsV2Repository {
         WHERE MATCH(p.PROBLEM_V2_TITLE) AGAINST(${title} IN BOOLEAN MODE)
         ${whereClause}
         ${orderClause}
-        LIMIT 1000;
+        LIMIT ${FULLTEXT_SEARCH_LIMIT};
       `,
     );
 
@@ -189,8 +190,8 @@ export class ProblemsV2Repository {
       return title.includes(search);
     });
     const totalCount = filtered.length;
-    const currentPageNo = pageNo ?? 1;
-    const currentPageSize = pageSize ?? 10;
+    const currentPageNo = pageNo ?? DEFAULT_PAGE_NO;
+    const currentPageSize = pageSize ?? DEFAULT_PAGE_SIZE;
     const offset = (currentPageNo - 1) * currentPageSize;
     const paged = filtered.slice(offset, offset + currentPageSize);
 
@@ -265,8 +266,8 @@ export class ProblemsV2Repository {
     }
 
     const orderBy = this.getProblemOrderBy(sort);
-    const skip = ((pageNo ?? 1) - 1) * (pageSize ?? 10);
-    const take = pageSize ?? 10;
+    const skip = ((pageNo ?? DEFAULT_PAGE_NO) - 1) * (pageSize ?? DEFAULT_PAGE_SIZE);
+    const take = pageSize ?? DEFAULT_PAGE_SIZE;
 
     const totalCount = await this.prismaService.problemV2.count({
       where,


### PR DESCRIPTION
## 작업 내용
- [x] `problems-collect.service.ts`: `console.log` → `this.logger.debug` 교체
- [x] `code.service.ts`: 매직넘버 `10` → `MAX_CODE_TEMPLATE_COUNT` 상수 추출
- [x] `pagination.constant.ts`: 공통 페이지네이션 상수 생성
- [x] `problems-v2.repository.ts`: `LIMIT 1000`, `pageSize ?? 10` 등 매직넘버 상수로 교체
- [x] `inquiry-problems-summary.dto.ts`: `@IsIn([10, 20, 50])` → `ALLOWED_PAGE_SIZES` 상수 사용

## 테스트
- [x] TypeScript 컴파일 정상 확인

## 관련 이슈
- ALGOGO-37