### PR TITLE
[ALGOGO-39] test: 핵심 모듈 단위 테스트 추가

### DIFF
--- a/src/execute/execute.service.spec.ts
+++ b/src/execute/execute.service.spec.ts
@@ -1,0 +1,81 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ExecuteService } from './execute.service';
+import bullmqConfig from '../config/bullmqConfig';
+import { CustomLogger } from '../logger/custom-logger';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+
+describe('ExecuteService', () => {
+  let service: ExecuteService;
+
+  const mockConfig = {
+    host: 'localhost',
+    port: 6379,
+    password: '',
+    queueName: 'test-queue',
+  };
+
+  const mockLogger = {
+    log: jest.fn(),
+    error: jest.fn(),
+    silly: jest.fn(),
+  };
+
+  const mockEventEmitter = {
+    emit: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ExecuteService,
+        { provide: bullmqConfig.KEY, useValue: mockConfig },
+        { provide: CustomLogger, useValue: mockLogger },
+        { provide: EventEmitter2, useValue: mockEventEmitter },
+      ],
+    }).compile();
+
+    service = module.get(ExecuteService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('generateJobId', () => {
+    it('provider를 포함한 고유 ID를 생성한다', async () => {
+      // When
+      const jobId = await service.generateJobId('JAVA');
+
+      // Then
+      expect(jobId).toMatch(/^JAVA_\d+_/);
+    });
+
+    it('호출할 때마다 다른 ID를 생성한다', async () => {
+      // When
+      const id1 = await service.generateJobId('PYTHON');
+      const id2 = await service.generateJobId('PYTHON');
+
+      // Then
+      expect(id1).not.toBe(id2);
+    });
+  });
+
+  describe('run', () => {
+    it('queue가 초기화되지 않으면 에러를 반환한다', async () => {
+      // Given - onModuleInit을 호출하지 않아 queue가 없음
+      const dto = {
+        jobId: 'test-job',
+        language: 'JAVA',
+        code: 'System.out.println("hello")',
+        inputList: ['1'],
+      };
+
+      // When
+      const result = await service.run(dto as never);
+
+      // Then
+      expect(result).toHaveProperty('code', '9999');
+      expect(result).toHaveProperty('result');
+    });
+  });
+});

--- a/src/jwt/jwt.service.spec.ts
+++ b/src/jwt/jwt.service.spec.ts
@@ -1,0 +1,142 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { JwtService } from './jwt.service';
+import {
+  JwtService as NestJwtService,
+  TokenExpiredError,
+  JsonWebTokenError,
+} from '@nestjs/jwt';
+import jwtConfig from '../config/jwtConfig';
+import { JwtTokenExpiredException } from '../common/errors/token/JwtTokenExpiredException';
+import { JwtInvalidTokenException } from '../common/errors/token/JwtInvalidTokenException';
+
+describe('JwtService', () => {
+  let service: JwtService;
+  let nestJwtService: jest.Mocked<NestJwtService>;
+
+  const mockConfig = {
+    jwtSecret: 'test-secret',
+    jwtAccessTokenExpiresIn: 3600,
+    jwtRefreshTokenExpiresIn: 86400,
+    prevJwtSecret: 'prev-secret',
+  };
+
+  beforeEach(async () => {
+    const mockNestJwtService = {
+      signAsync: jest.fn(),
+      verifyAsync: jest.fn(),
+      decode: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        JwtService,
+        { provide: NestJwtService, useValue: mockNestJwtService },
+        { provide: jwtConfig.KEY, useValue: mockConfig },
+      ],
+    }).compile();
+
+    service = module.get(JwtService);
+    nestJwtService = module.get(NestJwtService) as jest.Mocked<NestJwtService>;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('sign', () => {
+    it('토큰을 생성한다', async () => {
+      // Given
+      const payload = { sub: 'user-uuid' };
+      nestJwtService.signAsync.mockResolvedValue('signed-token');
+
+      // When
+      const result = await service.sign(payload, 3600);
+
+      // Then
+      expect(result).toBe('signed-token');
+      expect(nestJwtService.signAsync).toHaveBeenCalledWith(payload, {
+        secret: 'test-secret',
+        expiresIn: 3600,
+      });
+    });
+  });
+
+  describe('verify', () => {
+    it('유효한 토큰이면 페이로드를 반환한다', async () => {
+      // Given
+      const payload = { sub: 'user-uuid' };
+      nestJwtService.verifyAsync.mockResolvedValue(payload);
+
+      // When
+      const result = await service.verify('valid-token');
+
+      // Then
+      expect(result).toEqual(payload);
+    });
+
+    it('만료된 토큰이면 JwtTokenExpiredException을 던진다', async () => {
+      // Given
+      nestJwtService.verifyAsync.mockRejectedValue(
+        new TokenExpiredError('expired', new Date()),
+      );
+
+      // When & Then
+      await expect(service.verify('expired-token')).rejects.toThrow(
+        JwtTokenExpiredException,
+      );
+    });
+
+    it('현재 시크릿 실패 시 이전 시크릿으로 재검증한다', async () => {
+      // Given
+      const payload = { sub: 'user-uuid' };
+      nestJwtService.verifyAsync
+        .mockRejectedValueOnce(new JsonWebTokenError('invalid'))
+        .mockResolvedValueOnce(payload);
+
+      // When
+      const result = await service.verify('old-token');
+
+      // Then
+      expect(result).toEqual(payload);
+      expect(nestJwtService.verifyAsync).toHaveBeenCalledTimes(2);
+    });
+
+    it('양쪽 시크릿 모두 실패하면 JwtInvalidTokenException을 던진다', async () => {
+      // Given
+      nestJwtService.verifyAsync
+        .mockRejectedValueOnce(new JsonWebTokenError('invalid'))
+        .mockRejectedValueOnce(new JsonWebTokenError('invalid'));
+
+      // When & Then
+      await expect(service.verify('bad-token')).rejects.toThrow(
+        JwtInvalidTokenException,
+      );
+    });
+  });
+
+  describe('decode', () => {
+    it('토큰을 디코딩한다', async () => {
+      // Given
+      const payload = { sub: 'user-uuid' };
+      nestJwtService.decode.mockReturnValue(payload);
+
+      // When
+      const result = await service.decode('some-token');
+
+      // Then
+      expect(result).toEqual(payload);
+    });
+
+    it('디코딩 실패 시 JwtInvalidTokenException을 던진다', async () => {
+      // Given
+      nestJwtService.decode.mockImplementation(() => {
+        throw new Error('decode error');
+      });
+
+      // When & Then
+      await expect(service.decode('bad-token')).rejects.toThrow(
+        JwtInvalidTokenException,
+      );
+    });
+  });
+});

--- a/src/oauth-v2/oauth-v2.service.spec.ts
+++ b/src/oauth-v2/oauth-v2.service.spec.ts
@@ -1,0 +1,184 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { OauthV2Service } from './oauth-v2.service';
+import { OauthV2Repository } from './oauth-v2.repository';
+import { UsersService } from '../users/users.service';
+import { AuthV2Service } from '../auth-v2/auth-v2.service';
+import { OAUTH_STATE } from '../common/constants/oauth.contant';
+import { OAuthConflictException } from '../common/errors/oauth/OAuthConflictException';
+
+describe('OauthV2Service', () => {
+  let service: OauthV2Service;
+  let repository: jest.Mocked<OauthV2Repository>;
+  let usersService: jest.Mocked<UsersService>;
+  let authV2Service: jest.Mocked<AuthV2Service>;
+
+  const mockTokens = {
+    accessToken: 'access-token',
+    refreshToken: 'refresh-token',
+  };
+
+  beforeEach(async () => {
+    const mockRepository = {
+      findOne: jest.fn(),
+      createUserOAuth: jest.fn(),
+      updateUserOAuth: jest.fn(),
+    };
+
+    const mockUsersService = {
+      createUser: jest.fn(),
+    };
+
+    const mockAuthV2Service = {
+      login: jest.fn().mockResolvedValue(mockTokens),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OauthV2Service,
+        { provide: OauthV2Repository, useValue: mockRepository },
+        { provide: UsersService, useValue: mockUsersService },
+        { provide: AuthV2Service, useValue: mockAuthV2Service },
+      ],
+    }).compile();
+
+    service = module.get(OauthV2Service);
+    repository = module.get(OauthV2Repository) as jest.Mocked<OauthV2Repository>;
+    usersService = module.get(UsersService) as jest.Mocked<UsersService>;
+    authV2Service = module.get(AuthV2Service) as jest.Mocked<AuthV2Service>;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getOAuthState', () => {
+    it('OAuth 정보가 없으면 NEW 상태를 반환한다', async () => {
+      // Given
+      repository.findOne.mockResolvedValue(null);
+
+      // When
+      const result = await service.getOAuthState({ id: '123', provider: 'kakao' });
+
+      // Then
+      expect(result.state).toBe(OAUTH_STATE.NEW);
+      expect(result.user).toBeNull();
+    });
+
+    it('활성 연동이고 같은 유저면 CONNECTED_AND_ACTIVE를 반환한다', async () => {
+      // Given
+      const oauth = { userUuid: 'user-1', isActive: true };
+      repository.findOne.mockResolvedValue(oauth as never);
+
+      // When
+      const result = await service.getOAuthState({
+        id: '123',
+        provider: 'kakao',
+        userUuid: 'user-1',
+      });
+
+      // Then
+      expect(result.state).toBe(OAUTH_STATE.CONNECTED_AND_ACTIVE);
+    });
+
+    it('활성 연동이고 다른 유저면 CONNECTED_TO_OTHER_ACCOUNT를 반환한다', async () => {
+      // Given
+      const oauth = { userUuid: 'other-user', isActive: true };
+      repository.findOne.mockResolvedValue(oauth as never);
+
+      // When
+      const result = await service.getOAuthState({
+        id: '123',
+        provider: 'kakao',
+        userUuid: 'user-1',
+      });
+
+      // Then
+      expect(result.state).toBe(OAUTH_STATE.CONNECTED_TO_OTHER_ACCOUNT);
+    });
+  });
+
+  describe('registerOrLogin', () => {
+    const params = {
+      id: '123',
+      provider: 'kakao' as const,
+      name: '테스트',
+      email: 'test@test.com',
+      ip: '127.0.0.1',
+      userAgent: 'test-agent',
+    };
+
+    it('NEW 상태면 유저 생성 후 토큰을 반환한다', async () => {
+      // Given
+      repository.findOne.mockResolvedValue(null);
+      usersService.createUser.mockResolvedValue({ uuid: 'new-uuid' } as never);
+
+      // When
+      const result = await service.registerOrLogin(params);
+
+      // Then
+      expect(usersService.createUser).toHaveBeenCalled();
+      expect(authV2Service.login).toHaveBeenCalledWith(
+        expect.objectContaining({ userUuid: 'new-uuid' }),
+      );
+      expect(result).toEqual(mockTokens);
+    });
+
+    it('CONNECTED_AND_ACTIVE 상태면 바로 로그인한다', async () => {
+      // Given
+      const oauth = { userUuid: 'existing-uuid', isActive: true };
+      repository.findOne.mockResolvedValue(oauth as never);
+
+      // When
+      const result = await service.registerOrLogin(params);
+
+      // Then
+      expect(usersService.createUser).not.toHaveBeenCalled();
+      expect(authV2Service.login).toHaveBeenCalledWith(
+        expect.objectContaining({ userUuid: 'existing-uuid' }),
+      );
+      expect(result).toEqual(mockTokens);
+    });
+  });
+
+  describe('connectOAuthProvider', () => {
+    const params = { id: '123', provider: 'kakao' as const, userUuid: 'user-1' };
+
+    it('NEW 상태면 OAuth를 생성한다', async () => {
+      // Given
+      repository.findOne.mockResolvedValue(null);
+
+      // When
+      await service.connectOAuthProvider(params);
+
+      // Then
+      expect(repository.createUserOAuth).toHaveBeenCalledWith(params);
+    });
+
+    it('다른 계정에 활성 연동이면 OAuthConflictException을 던진다', async () => {
+      // Given
+      const oauth = { userUuid: 'other-user', isActive: true };
+      repository.findOne.mockResolvedValue(oauth as never);
+
+      // When & Then
+      await expect(service.connectOAuthProvider(params)).rejects.toThrow(
+        OAuthConflictException,
+      );
+    });
+  });
+
+  describe('disconnectOAuthProvider', () => {
+    it('OAuth 연동을 해제한다', async () => {
+      // Given
+      const params = { id: '123', provider: 'kakao' as const, userUuid: 'user-1' };
+
+      // When
+      await service.disconnectOAuthProvider(params);
+
+      // Then
+      expect(repository.updateUserOAuth).toHaveBeenCalledWith({
+        ...params,
+        isActive: false,
+      });
+    });
+  });
+});

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -1,0 +1,140 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UsersService } from './users.service';
+import { UsersRepository } from './users.repository';
+import { UserNotFoundException } from '../common/errors/user/UserNotFoundException';
+import { UserInactiveException } from '../common/errors/user/UserInactiveException';
+import { USER_STATE } from '../common/constants/user.constant';
+
+describe('UsersService', () => {
+  let service: UsersService;
+  let repository: jest.Mocked<UsersRepository>;
+
+  beforeEach(async () => {
+    const mockRepository = {
+      findUser: jest.fn(),
+      createUser: jest.fn(),
+      findUserSummaryByUuid: jest.fn(),
+      insertLoginHistory: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UsersService,
+        { provide: UsersRepository, useValue: mockRepository },
+      ],
+    }).compile();
+
+    service = module.get(UsersService);
+    repository = module.get(UsersRepository) as jest.Mocked<UsersRepository>;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getUser', () => {
+    it('유저가 존재하면 반환한다', async () => {
+      // Given
+      const user = { uuid: 'test-uuid', name: '테스트' };
+      repository.findUser.mockResolvedValue(user as never);
+
+      // When
+      const result = await service.getUser({ userUuid: 'test-uuid' });
+
+      // Then
+      expect(result).toEqual(user);
+      expect(repository.findUser).toHaveBeenCalledWith({ userUuid: 'test-uuid' });
+    });
+
+    it('유저가 없으면 UserNotFoundException을 던진다', async () => {
+      // Given
+      repository.findUser.mockResolvedValue(null as never);
+
+      // When & Then
+      await expect(service.getUser({ userUuid: 'none' })).rejects.toThrow(
+        UserNotFoundException,
+      );
+    });
+  });
+
+  describe('createUser', () => {
+    it('유저를 생성하고 반환한다', async () => {
+      // Given
+      const params = { provider: 'kakao' as const, id: '123', name: '테스트', email: 'test@test.com' };
+      const created = { uuid: 'new-uuid', ...params };
+      repository.createUser.mockResolvedValue(created as never);
+
+      // When
+      const result = await service.createUser(params);
+
+      // Then
+      expect(result).toEqual(created);
+      expect(repository.createUser).toHaveBeenCalledWith(params);
+    });
+  });
+
+  describe('validateUser', () => {
+    it('활성 유저면 UserSummary를 반환한다', async () => {
+      // Given
+      const user = {
+        uuid: 'test-uuid',
+        name: '테스트',
+        state: USER_STATE.ACTIVE,
+        userRoleList: [{ role: 'USER' }],
+      };
+      repository.findUserSummaryByUuid.mockResolvedValue(user as never);
+
+      // When
+      const result = await service.validateUser('test-uuid');
+
+      // Then
+      expect(result.roles).toEqual(['USER']);
+      expect(result.state).toBe(USER_STATE.ACTIVE);
+    });
+
+    it('유저가 없으면 UserNotFoundException을 던진다', async () => {
+      // Given
+      repository.findUserSummaryByUuid.mockResolvedValue(null as never);
+
+      // When & Then
+      await expect(service.validateUser('none')).rejects.toThrow(
+        UserNotFoundException,
+      );
+    });
+
+    it('비활성 유저면 UserInactiveException을 던진다', async () => {
+      // Given
+      const user = {
+        uuid: 'test-uuid',
+        name: '테스트',
+        state: USER_STATE.INACTIVE,
+        userRoleList: [],
+      };
+      repository.findUserSummaryByUuid.mockResolvedValue(user as never);
+
+      // When & Then
+      await expect(service.validateUser('test-uuid')).rejects.toThrow(
+        UserInactiveException,
+      );
+    });
+  });
+
+  describe('insertLoginHistory', () => {
+    it('로그인 이력을 저장한다', async () => {
+      // Given
+      const params = {
+        userUuid: 'test-uuid',
+        type: 'KAKAO',
+        ip: '127.0.0.1',
+        userAgent: 'test-agent',
+      };
+      repository.insertLoginHistory.mockResolvedValue(undefined as never);
+
+      // When
+      await service.insertLoginHistory(params);
+
+      // Then
+      expect(repository.insertLoginHistory).toHaveBeenCalledWith(params);
+    });
+  });
+});


### PR DESCRIPTION
## 작업 내용
- [x] `users.service.spec.ts`: getUser, createUser, validateUser, insertLoginHistory (7 tests)
- [x] `jwt.service.spec.ts`: sign, verify, decode + 이전 시크릿 폴백 검증 (7 tests)
- [x] `oauth-v2.service.spec.ts`: getOAuthState, registerOrLogin, connectOAuthProvider, disconnectOAuthProvider (7 tests)
- [x] `execute.service.spec.ts`: generateJobId, run 에러 핸들링 (4 tests)

## 테스트
- [x] 25개 테스트 모두 통과

## 관련 이슈
- ALGOGO-39