### PR TITLE
[ALGOGO-41] refactor: 코드 규칙 위반 수정 및 문서 정리

### DIFF
--- a/docs/adr/ALGOGO-29-nestjs-11-upgrade.md
+++ b/docs/adr/ALGOGO-29-nestjs-11-upgrade.md
@@ -1,0 +1,30 @@
+# ALGOGO-29: NestJS 10 → 11 메이저 업그레이드
+
+## 문제
+
+NestJS 10은 Express v4 기반으로, 보안 패치와 성능 개선이 제한적이었다. NestJS 11이 Express v5를 기본 통합하면서 라우팅 엔진과 타입이 변경되었다.
+
+## 검토한 대안
+
+| 대안 | 설명 | 장점 | 단점 |
+|------|------|------|------|
+| A. 현재 유지 | NestJS 10 계속 사용 | 변경 리스크 없음 | 보안 패치 지연, 신규 기능 사용 불가 |
+| B. NestJS 11 업그레이드 | 전체 @nestjs/* 패키지 v11 | Express v5, 최신 보안, CacheModule Keyv 지원 | 와일드카드 라우트 변경, JWT 타입 변경 |
+
+## 결정
+
+B안: NestJS 11로 업그레이드했다.
+
+## 이유
+
+CacheModule이 이미 Keyv 기반(`createKeyv()`)으로 구현되어 있어 가장 큰 breaking change가 이미 해결된 상태였다. 실제 수정이 필요했던 부분은 3곳뿐:
+1. 미들웨어 와일드카드: `forRoutes('*')` → `forRoutes('*splat')` (Express v5 path-to-regexp 변경)
+2. JWT `expiresIn` 타입: `string | number` → `number` (jwt v11 overload 변경)
+3. passport-oauth2 `session` 속성: StrategyOptions 타입에서 제거됨
+
+109개 테스트 전부 통과 확인 후 머지했다.
+
+## 참고
+
+- PR: #136
+- [NestJS 11 Migration Guide](https://docs.nestjs.com/migration-guide)

--- a/docs/adr/ALGOGO-34-cookie-service-extraction.md
+++ b/docs/adr/ALGOGO-34-cookie-service-extraction.md
@@ -1,0 +1,25 @@
+# ALGOGO-34: 쿠키 설정 로직을 TokenCookieService로 추출
+
+## 문제
+
+auth-v2와 oauth-v2 컨트롤러에서 동일한 쿠키 설정 로직(httpOnly, secure, sameSite, maxAge)이 중복되어 있었다. 쿠키 옵션을 변경하면 두 곳을 동시에 수정해야 했다.
+
+## 검토한 대안
+
+| 대안 | 설명 | 장점 | 단점 |
+|------|------|------|------|
+| A. 유틸리티 함수 | 순수 함수로 쿠키 옵션 생성 | DI 불필요 | JwtConfig를 매번 인자로 전달해야 함 |
+| B. jwt 모듈에 Service 추가 | TokenCookieService를 jwt 모듈에 등록 | DI로 config 자동 주입, 두 모듈 모두 JwtModule에 접근 가능 | jwt 모듈의 책임 범위가 넓어짐 |
+| C. 별도 cookie 모듈 생성 | 독립 모듈로 분리 | 관심사 분리 깔끔 | 과도한 분리, 모듈 수 증가 |
+
+## 결정
+
+B안: jwt 모듈에 TokenCookieService를 추가했다.
+
+## 이유
+
+쿠키 설정은 JWT 토큰의 만료시간(jwtConfig)에 의존한다. jwt 모듈이 이미 두 컨트롤러 모듈에서 import되고 있어 추가 의존성이 없다. 별도 모듈을 만들면 config 하나 때문에 모듈이 늘어나는데, 현재 규모에서는 과하다.
+
+## 참고
+
+- PR: #129

--- a/docs/adr/ALGOGO-35-config-module-unification.md
+++ b/docs/adr/ALGOGO-35-config-module-unification.md
@@ -1,0 +1,24 @@
+# ALGOGO-35: process.env 직접 접근을 ConfigModule로 통일
+
+## 문제
+
+filter, service, adapter 등 여러 파일에서 `process.env.NODE_ENV`를 직접 읽고 있었다. 테스트에서 환경을 주입하기 어렵고, 환경 변수명이 변경되면 grep으로 찾아야 했다.
+
+## 검토한 대안
+
+| 대안 | 설명 | 장점 | 단점 |
+|------|------|------|------|
+| A. ConfigService.get() 직접 사용 | 각 파일에서 ConfigService 주입 | NestJS 기본 패턴 | 매번 문자열 키로 접근, 타입 안전성 없음 |
+| B. registerAs + 타입 주입 | appConfig 생성 후 `@Inject(appConfig.KEY)` | 타입 안전, 자동완성 지원 | config 파일 하나 추가 |
+
+## 결정
+
+B안: `appConfig`를 `registerAs()`로 생성하고, 타입이 보장되는 주입 방식을 사용했다.
+
+## 이유
+
+프로젝트의 다른 config(jwtConfig, redisConfig 등)가 모두 `registerAs()` 패턴을 사용한다. 일관성을 유지하면서 `ConfigType<typeof appConfig>`로 타입 안전성을 확보했다. RedisIoAdapter는 NestJS DI 밖이므로 `app.get(redisConfig.KEY)`로 app context에서 가져왔다.
+
+## 참고
+
+- PR: #130

--- a/docs/adr/ALGOGO-38-shared-problem-order-by.md
+++ b/docs/adr/ALGOGO-38-shared-problem-order-by.md
@@ -1,0 +1,24 @@
+# ALGOGO-38: getProblemOrderBy 중복 코드 제거
+
+## 문제
+
+problems(v1)과 problems-v2 두 repository에 동일한 `getProblemOrderBy` private 메서드가 존재했다. 정렬 로직 변경 시 두 곳을 동시에 수정해야 하고, 정렬 상수도 `PROBLEM_SORT`와 `PROBLEM_SORT_MAP`으로 이름만 다른 동일한 값이 있었다.
+
+## 검토한 대안
+
+| 대안 | 설명 | 장점 | 단점 |
+|------|------|------|------|
+| A. v1 모듈에서 export | problems 모듈의 함수를 problems-v2에서 import | 기존 코드 이동 최소 | v2가 v1에 의존하게 됨 (역방향) |
+| B. common/utils에 추출 | 두 모듈 모두 common에서 import | 양방향 의존 없음, 진정한 공유 코드 | common/ 파일 하나 추가 |
+
+## 결정
+
+B안: `common/utils/problem-order-by.util.ts`에 순수 함수로 추출하고, `common/constants/problem-sort.constant.ts`에 상수를 통합했다.
+
+## 이유
+
+v2가 v1에 의존하면 v1 삭제 시 다시 이동해야 한다. common/에 두면 두 모듈 모두 안정적으로 참조할 수 있다. 정렬 로직은 Prisma orderBy 객체를 반환하는 순수 함수이므로 common/utils에 적합하다.
+
+## 참고
+
+- PR: #133

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,7 +18,7 @@ NestJS-based algorithmic problem platform (single monolith). Package.json has mu
 Each module follows **Controller -> Service -> Repository** pattern with DTOs in a `dto/` subfolder.
 
 - **Auth & Users**: `auth-v2/`, `oauth-v2/`, `auth-guard/`, `authorization/`, `users/`, `me/`, `jwt/`
-- **Problems**: `problems/` (v1 legacy), `problems-v2/` (current), `problems-collect/`, `problems-report/`, `problem-site/`
+- **Problems**: `problems/` (v1 legacy), `problems-v2/` (current), `problems-collect/`, `problem-site/`
 - **Code Execution**: `execute/` (WebSocket gateway + BullMQ), `code/` (templates/settings), `rate-limit/`
 - **Infrastructure**: `prisma/`, `redis/`, `s3/`, `config/`, `crypto/`, `image/`, `logger/`
 - **Cross-cutting**: `common/` (decorators, types, errors), `filters/`, `interceptors/`, `middlewares/`
@@ -78,7 +78,7 @@ Environment files: `.development.env` (local), `.production.env` (prod). `NODE_E
 
 ## Key Conventions
 
-- **TypeScript**: `strictNullChecks: false`, `noImplicitAny: false`
+- **TypeScript**: `strict: true` (strictNullChecks, noImplicitAny 등 전부 활성)
 - **Imports**: Relative paths from `baseUrl: "./"`, no path aliases
 - **Swagger**: Available at `/api` in development mode only
 - **CORS**: `http://localhost:5173` allowed in development
@@ -87,4 +87,4 @@ Environment files: `.development.env` (local), `.production.env` (prod). `NODE_E
 - **Prisma column mapping**: `@@map()` and `@map()` to SCREAMING_SNAKE_CASE DB columns
 - **Composite unique keys**: `(source, sourceId)` on problems, `(userUuid, problemUuid, language)` on ProblemCode
 - **V1/V2 pattern**: Legacy modules (`problems/`, `auth/`) coexist with v2 replacements. New work should use v2 modules.
-- **Prisma schema**: Actual path is `prisma/schema.prisma`. Package.json scripts reference `libs/shared-prisma/prisma/schema.prisma` (outdated).
+- **Prisma schema**: `prisma/schema.prisma`

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,82 +1,37 @@
 # Algogo Workflow
 
-Global rules (test separation, review criteria, phases) are in ~/CLAUDE.md.
-This file contains Algogo-specific execution plan only.
+## 개발 프로세스
 
-## Team
+모든 작업은 Linear 이슈 기반으로 진행한다.
 
-| Agent | Role |
-|-------|------|
-| ryan-dahl | Node.js/TypeScript backend lead |
-| expert-backend | API/DB/auth architecture |
-| expert-refactoring | V1->V2 consolidation, code cleanup |
-| kent-beck | Test agent (writes all tests, separate from implementers) |
-| expert-security | Security audit, vulnerability fixes |
-| expert-performance | WebSocket/BullMQ/DB optimization |
-| expert-devops | CI/CD, Docker, deployment |
-| manager-docs | API docs, dev guides |
-| expert-debug | Bug diagnosis, troubleshooting |
+```
+Linear 이슈 생성 → 브랜치 생성 → 코드 작업 → 커밋 → PR → 셀프 리뷰 → 머지 → Linear Done
+```
 
-## Automated Gates (Algogo-specific)
+## 브랜치 전략
 
-- ESLint: `@typescript-eslint/no-explicit-any: error`
-- Jest coverage threshold: 85%
-- CI check: every `*.service.ts` has matching `*.spec.ts`
-- Setup responsibility: expert-devops (Phase 2)
+- `main`: 릴리스 가능한 안정 버전
+- `dev/algogo`: 개발 통합 브랜치
+- `ALGOGO-{번호}`: 기능 브랜치 (dev에서 분기, dev로 squash merge)
 
-## Phase 1: Audit
+상세 규칙: `.claude/rules/git.md`
 
-Read-only. 4 agents parallel.
+## 이슈 관리
 
-| Agent | Task | Output |
-|-------|------|--------|
-| expert-security | OAuth/JWT flow, input validation, CSRF | Vulnerability report |
-| kent-beck | Untested critical paths, test gap analysis | Test gap report |
-| expert-performance | WebSocket latency, BullMQ throughput, slow queries | Performance baseline |
-| expert-refactoring | V1/V2 overlap, any-type inventory, error handling gaps | Refactoring priority list |
+- 모든 작업은 Linear 이슈로 시작한다
+- 이슈 없이 코드를 수정하지 않는다
+- 상태 전환: Backlog → Todo → In Progress → In Review → Done
 
-## Phase 2: Foundation
+상세 규칙: `.claude/rules/linear.md`
 
-3 tracks parallel. Complete when CI pipeline runs green.
+## 코드 리뷰
 
-| Agent | Task |
-|-------|------|
-| expert-devops | Dockerfile, docker-compose, GitHub Actions CI, ESLint rule additions |
-| kent-beck | Jest config, shared mocks/utils, first tests for auth + execute |
-| expert-security | Fix critical vulnerabilities from Phase 1 |
+- 셀프 리뷰 후 머지 허용
+- TypeScript 컴파일 에러 없을 것
+- 기존 테스트 통과할 것
 
-## Phase 3: Core
+## 의사결정 기록
 
-4 tracks parallel. Non-overlapping module assignment to avoid file conflicts.
+코드만으로 드러나지 않는 "왜"가 있으면 `docs/adr/`에 ADR을 작성한다.
 
-| Agent | Task |
-|-------|------|
-| expert-refactoring + ryan-dahl | V1 removal, TypeScript strict mode, error handling standardization |
-| kent-beck | Test coverage for all services + repositories, E2E suite |
-| expert-performance | WebSocket/BullMQ optimization, DB query tuning |
-| expert-backend | API consistency, Repository pattern enforcement |
-
-Flow per change:
-1. Implementation agent writes code
-2. kent-beck writes tests against public interface
-3. Tests fail → back to implementation agent
-4. Tests pass + CI green → done
-
-## Phase 4: Stabilize
-
-3 tracks parallel.
-
-| Agent | Task |
-|-------|------|
-| manager-docs | API docs, dev setup guide, architecture docs, DB schema docs |
-| expert-security | Final security review of Phase 3 changes |
-| expert-debug | Integration testing, bug triage |
-
-## Phase 5: Ongoing
-
-| Agent | Role |
-|-------|------|
-| ryan-dahl | New features |
-| expert-backend | Architecture evolution |
-| kent-beck | Test writing for all new code |
-| expert-debug | Bug fixes |
+상세 규칙: `docs/adr/README.md`

--- a/src/auth-v2/auth-v2.service.ts
+++ b/src/auth-v2/auth-v2.service.ts
@@ -8,7 +8,7 @@ import { JwtInvalidTokenException } from '../common/errors/token/JwtInvalidToken
 import JwtConfig from '../config/jwtConfig';
 import { ConfigType } from '@nestjs/config';
 import { CustomLogger } from '../logger/custom-logger';
-import { TokenUser } from 'src/common/types/request.type';
+import { TokenUser } from '../common/types/request.type';
 @Injectable()
 export class AuthV2Service {
   constructor(

--- a/src/code/code.repository.ts
+++ b/src/code/code.repository.ts
@@ -62,35 +62,29 @@ export class CodeRepository {
     });
   }
 
+  private async getDefaultTemplates(userUuid: string) {
+    const defaults = await this.prisma.codeDefaultTemplate.findMany({
+      where: { userUuid },
+      select: { codeTemplateNo: true },
+    });
+
+    return this.prisma.codeTemplate.findMany({
+      where: { no: { in: defaults.map((d) => d.codeTemplateNo) } },
+      select: {
+        language: true,
+        uuid: true,
+        name: true,
+        content: true,
+        description: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+  }
+
   async getCodeTemplateResult(userUuid: string) {
     const [defaultList, summaryList] = await Promise.all([
-      this.prisma.codeDefaultTemplate
-        .findMany({
-          where: { userUuid },
-          select: {
-            codeTemplateNo: true,
-          },
-        })
-        .then((defaults) =>
-          this.prisma.codeTemplate.findMany({
-            where: {
-              no: {
-                in: defaults.map((d) => d.codeTemplateNo),
-              },
-            },
-            select: {
-              language: true,
-              uuid: true,
-              name: true,
-              content: true,
-              description: true,
-              createdAt: true,
-              updatedAt: true,
-            },
-          }),
-        ),
-
-      // 전체 템플릿 목록
+      this.getDefaultTemplates(userUuid),
       this.prisma.codeTemplate.findMany({
         where: { userUuid },
         select: {

--- a/src/code/dto/RequestUpsertProblemCodeDto.ts
+++ b/src/code/dto/RequestUpsertProblemCodeDto.ts
@@ -2,7 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { LanguageProvider } from '../../common/types/language.type';
 import { IsString, IsUUID, IsEnum, IsNotEmpty } from 'class-validator';
 import { MaxBytes } from '../../common/decorators/MaxBytes';
-import { LANGUAGE_PROVIDER } from 'src/common/constants/language.constant';
+import { LANGUAGE_PROVIDER } from '../../common/constants/language.constant';
 
 export default class RequestUpsertProblemCodeDto {
   @ApiProperty({

--- a/src/code/dto/ResponseCodeTemplateSummary.ts
+++ b/src/code/dto/ResponseCodeTemplateSummary.ts
@@ -1,6 +1,6 @@
 import { LanguageProvider } from '../../common/types/language.type';
 import { ApiProperty } from '@nestjs/swagger';
-import { LANGUAGE_PROVIDER } from 'src/common/constants/language.constant';
+import { LANGUAGE_PROVIDER } from '../../common/constants/language.constant';
 
 export default class ResponseCodeTemplateSummary {
   @ApiProperty({

--- a/src/code/dto/ResponseProblemCodeDto.ts
+++ b/src/code/dto/ResponseProblemCodeDto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { LanguageProvider } from '../../common/types/language.type';
-import { LANGUAGE_PROVIDER } from 'src/common/constants/language.constant';
+import { LANGUAGE_PROVIDER } from '../../common/constants/language.constant';
 
 export class ResponseProblemCodeDto {
   @ApiProperty({

--- a/src/execute/execute.gateway.ts
+++ b/src/execute/execute.gateway.ts
@@ -151,7 +151,6 @@ export class ExecuteGateway {
         processTime: 0,
         memory: 0,
       };
-    } finally {
     }
   }
 

--- a/src/execute/execute.service.ts
+++ b/src/execute/execute.service.ts
@@ -88,7 +88,6 @@ export class ExecuteService implements OnModuleInit {
         code: '9999',
         result: '예외 오류',
       };
-    } finally {
     }
   }
 }

--- a/src/jwt/token-cookie.service.ts
+++ b/src/jwt/token-cookie.service.ts
@@ -2,6 +2,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import { ConfigType } from '@nestjs/config';
 import { Response } from 'express';
 import JwtConfig from '../config/jwtConfig';
+import appConfig from '../config/appConfig';
 
 @Injectable()
 export class TokenCookieService {
@@ -10,8 +11,10 @@ export class TokenCookieService {
   constructor(
     @Inject(JwtConfig.KEY)
     private readonly jwtConfig: ConfigType<typeof JwtConfig>,
+    @Inject(appConfig.KEY)
+    private readonly appCfg: ConfigType<typeof appConfig>,
   ) {
-    this.isProduction = process.env.NODE_ENV !== 'development';
+    this.isProduction = !appCfg.isDevelopment;
   }
 
   setAuthCookies(

--- a/src/me/dto/RequestUpdateSocialDto.ts
+++ b/src/me/dto/RequestUpdateSocialDto.ts
@@ -1,6 +1,6 @@
 import { IsIn, IsString } from 'class-validator';
 import { SocialProvider } from '../../common/types/social.type';
-import { SOCIAL_PROVIDER } from 'src/common/constants/social.constant';
+import { SOCIAL_PROVIDER } from '../../common/constants/social.constant';
 
 export class RequestUpdateSocialDto {
   @IsIn(Object.values(SOCIAL_PROVIDER), {

--- a/src/me/dto/ResponseSocialDto.ts
+++ b/src/me/dto/ResponseSocialDto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { SocialProvider } from '../../common/types/social.type';
-import { SOCIAL_PROVIDER } from 'src/common/constants/social.constant';
+import { SOCIAL_PROVIDER } from '../../common/constants/social.constant';
 
 export class ResponseSocialDto {
   @ApiProperty({ enum: SOCIAL_PROVIDER, description: '소셜 미디어 제공자' })

--- a/src/problem-site/problem-site.controller.ts
+++ b/src/problem-site/problem-site.controller.ts
@@ -19,9 +19,9 @@ import { Roles } from '../common/decorators/authorization/roles.decorator';
 import { ROLES } from '../common/constants/roles.constants';
 import { ProblemSiteService } from './problem-site.service';
 import { CreateProblemSiteDto } from './dto/create-problem-site.dto';
-import { TokenUser } from 'src/common/types/request.type';
-import { User } from 'src/common/decorators/contexts/user.decorator';
-import { ProblemSiteProvider } from 'src/common/types/problem-site.type';
+import { TokenUser } from '../common/types/request.type';
+import { User } from '../common/decorators/contexts/user.decorator';
+import { ProblemSiteProvider } from '../common/types/problem-site.type';
 
 @ApiTags('문제 사이트 관리')
 @ApiBearerAuth('Authorization')

--- a/src/problem-site/problem-site.service.ts
+++ b/src/problem-site/problem-site.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { ProblemSiteRepository } from './problem-site.repository';
-import { ProblemSiteProvider } from 'src/common/types/problem-site.type';
+import { ProblemSiteProvider } from '../common/types/problem-site.type';
 
 @Injectable()
 export class ProblemSiteService {

--- a/src/problems-v2/dto/problem-summary.dto.ts
+++ b/src/problems-v2/dto/problem-summary.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { ProblemType } from '../types/problem.type';
-import { UserProblemState } from 'src/common/types/user.type';
+import { UserProblemState } from '../../common/types/user.type';
 
 export class ProblemSummaryDto {
   @ApiProperty({


### PR DESCRIPTION
## 작업 내용
- [x] `src/` 절대 경로 import → 상대 경로 변환 (9개 파일)
- [x] `token-cookie.service`: `process.env` → `appConfig` 주입
- [x] 빈 `finally {}` 블록 제거 (execute.service, execute.gateway)
- [x] `.then()` 체이닝 → `async/await` (code.repository)
- [x] `docs/workflow.md`: MoAI 기반 → 실제 워크플로우 재작성
- [x] `docs/architecture.md`: strict 모드, 삭제 모듈, Prisma 경로 수정
- [x] ADR 4건 소급 작성 (ALGOGO-29, 34, 35, 38)

## 테스트
- [x] TypeScript 컴파일 정상
- [x] 109개 테스트 통과

## 관련 이슈
- ALGOGO-41