### PR TITLE
[ALGOGO-45] chore: v1 API deprecated 표시 및 app.controller 정리

### DIFF
--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,12 +1,9 @@
 import { Controller, Get } from '@nestjs/common';
-import { AppService } from './app.service';
 
 @Controller()
 export class AppController {
-  constructor(private readonly appService: AppService) {}
-
-  @Get('/')
-  async sayHello() {
-    return 'hello1';
+  @Get('/health')
+  health() {
+    return { status: 'ok' };
   }
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,6 +1,5 @@
 import { MiddlewareConsumer, Module } from '@nestjs/common';
 import { AppController } from './app.controller';
-import { AppService } from './app.service';
 import { ConfigModule, ConfigType } from '@nestjs/config';
 import { validationSchema } from './config/validationSchema';
 import { ProblemsModule } from './problems/problems.module';
@@ -127,7 +126,6 @@ import { createKeyv } from '@keyv/redis';
       provide: APP_INTERCEPTOR,
       useClass: ResponseInterceptor,
     },
-    AppService,
   ],
 })
 export class AppModule {

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -1,8 +1,0 @@
-import { Injectable } from '@nestjs/common';
-
-@Injectable()
-export class AppService {
-  getHello(): string {
-    return 'Hello World!';
-  }
-}

--- a/src/problems/problems.controller.ts
+++ b/src/problems/problems.controller.ts
@@ -14,7 +14,7 @@ import { ResponseDto } from '../common/dto/ResponseDto';
 import { CustomLogger } from '../logger/custom-logger';
 import { RequestProblemSummaryListDto } from './dto/RequestProblemSummaryListDto';
 
-@ApiTags('문제 관련 API')
+@ApiTags('[Deprecated] 문제 관련 API v1')
 @ApiBadRequestErrorResponse()
 @ApiExtraModels(ResponseProblemSummaryListDto, ResponseDto)
 @Controller('api/v1/problems')
@@ -27,6 +27,7 @@ export class ProblemsController {
   @ApiOperation({
     summary: '문제 요약 리스트',
     description: '여러 문제의 요약 정보를 불러온다',
+    deprecated: true,
   })
   @ApiResponse({
     status: HttpStatus.OK,
@@ -58,6 +59,7 @@ export class ProblemsController {
   @ApiOperation({
     summary: '문제 상세조회',
     description: '문제에 대한 상세 정보를 가져온다',
+    deprecated: true,
   })
   @ApiResponse({
     status: HttpStatus.OK,


### PR DESCRIPTION
## 작업 내용
- [x] problems v1 controller에 `[Deprecated]` ApiTags 및 `deprecated: true` ApiOperation 추가
- [x] app.controller.ts를 health check 엔드포인트(`GET /health`)로 교체
- [x] 미사용 app.service.ts 삭제
- [x] app.module.ts에서 AppService 제거

## 테스트
- [x] `tsc --noEmit` 통과 (기존 axios 타입 에러만 존재)
- [x] `pnpm test` 기존과 동일한 결과 (84 tests passed, 기존 8 suites 실패는 변경 전과 동일)

## 관련 이슈
- ALGOGO-45