### PR TITLE
[ALGOGO-50] test: 단위 테스트 누락 시나리오 보강

### DIFF
--- a/src/code/code.service.spec.ts
+++ b/src/code/code.service.spec.ts
@@ -3,16 +3,35 @@ import { CodeService } from './code.service';
 import { CodeRepository } from './code.repository';
 import { RedisService } from '../redis/redis.service';
 import { AppLogger } from '../logger/app-logger';
+import { NotFoundCodeSettingException } from './errors/NotFoundCodeSettingException';
 import { NotFoundCodeTemplateException } from './errors/NotFoundCodeTemplateException';
+import { CodeTemplateLimitExceededException } from './errors/CodeTemplateLimitExceededException';
+import { NotFoundProblemException } from './errors/NotFoundProblemException';
+import { NotFoundProblemCode } from './errors/NotFoundProblemCode';
+import { MAX_CODE_TEMPLATE_COUNT } from './constants';
 
 describe('CodeService 단위 테스트', () => {
   let service: CodeService;
+  let repository: jest.Mocked<CodeRepository>;
+  let redisService: jest.Mocked<RedisService>;
 
-  const mockCodeRepository: Partial<CodeRepository> = {
+  const mockCodeRepository = {
+    getCodeSetting: jest.fn(),
+    upsertCodeSetting: jest.fn(),
+    getCodeTemplateResult: jest.fn(),
     getCodeTemplate: jest.fn(),
+    createCodeTemplate: jest.fn(),
+    selectTotalCodeTemplateCount: jest.fn(),
+    getCodeTemplateNo: jest.fn(),
+    updateCodeTempltae: jest.fn(),
+    deleteCodeTemplate: jest.fn(),
+    upsertCodeDefaultTemplate: jest.fn(),
+    problemUuidToProblemNo: jest.fn(),
+    getProblemCodes: jest.fn(),
+    upsertProblemCode: jest.fn(),
   };
 
-  const mockRedisService: Partial<RedisService> = {
+  const mockRedisService = {
     get: jest.fn(),
     set: jest.fn(),
   };
@@ -23,8 +42,6 @@ describe('CodeService 단위 테스트', () => {
   };
 
   beforeEach(async () => {
-    jest.clearAllMocks();
-
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         CodeService,
@@ -35,6 +52,84 @@ describe('CodeService 단위 테스트', () => {
     }).compile();
 
     service = module.get<CodeService>(CodeService);
+    repository = module.get(CodeRepository) as jest.Mocked<CodeRepository>;
+    redisService = module.get(RedisService) as jest.Mocked<RedisService>;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getCodeSetting', () => {
+    const userUuid = 'user-uuid-1';
+
+    it('코드 설정이 존재하면 반환한다', async () => {
+      // Given
+      const mockSetting = { fontSize: 14, tabSize: 2 };
+      repository.getCodeSetting.mockResolvedValue(mockSetting as never);
+
+      // When
+      const result = await service.getCodeSetting(userUuid);
+
+      // Then
+      expect(result).toEqual(mockSetting);
+      expect(repository.getCodeSetting).toHaveBeenCalledWith(userUuid);
+    });
+
+    it('코드 설정이 없으면 NotFoundCodeSettingException을 던진다', async () => {
+      // Given
+      repository.getCodeSetting.mockResolvedValue(null as never);
+
+      // When & Then
+      await expect(service.getCodeSetting(userUuid)).rejects.toThrow(
+        NotFoundCodeSettingException,
+      );
+    });
+  });
+
+  describe('upsertCodeSetting', () => {
+    it('repository에 위임한다', async () => {
+      // Given
+      const dto = { userUuid: 'user-uuid-1', fontSize: 16, tabSize: 4 };
+      const mockResult = { ...dto };
+      repository.upsertCodeSetting.mockResolvedValue(mockResult as never);
+
+      // When
+      const result = await service.upsertCodeSetting(dto as never);
+
+      // Then
+      expect(result).toEqual(mockResult);
+      expect(repository.upsertCodeSetting).toHaveBeenCalledWith(dto);
+    });
+  });
+
+  describe('getCodeTemplateResult', () => {
+    const userUuid = 'user-uuid-1';
+
+    it('summaryList와 defaultList의 language를 매핑하여 반환한다', async () => {
+      // Given
+      const mockData = {
+        summaryList: [
+          { uuid: 'uuid-1', name: '템플릿1', language: 'JAVA' },
+          { uuid: 'uuid-2', name: '템플릿2', language: 'PYTHON' },
+        ],
+        defaultList: [
+          { language: 'JAVA', codeTemplateUuid: 'uuid-1' },
+        ],
+      };
+      repository.getCodeTemplateResult.mockResolvedValue(mockData as never);
+
+      // When
+      const result = await service.getCodeTemplateResult(userUuid);
+
+      // Then
+      expect(result.summaryList).toHaveLength(2);
+      expect(result.summaryList[0].language).toBe('JAVA');
+      expect(result.summaryList[1].language).toBe('PYTHON');
+      expect(result.defaultList).toHaveLength(1);
+      expect(result.defaultList[0].language).toBe('JAVA');
+      expect(repository.getCodeTemplateResult).toHaveBeenCalledWith(userUuid);
+    });
   });
 
   describe('getCodeTemplate', () => {
@@ -52,16 +147,14 @@ describe('CodeService 단위 테스트', () => {
         createdAt: new Date(),
         updatedAt: new Date(),
       };
-      (mockCodeRepository.getCodeTemplate as jest.Mock).mockResolvedValue(
-        mockTemplate,
-      );
+      repository.getCodeTemplate.mockResolvedValue(mockTemplate as never);
 
       // When
       const result = await service.getCodeTemplate({ userUuid, uuid });
 
       // Then
       expect(result).toEqual(mockTemplate);
-      expect(mockCodeRepository.getCodeTemplate).toHaveBeenCalledWith({
+      expect(repository.getCodeTemplate).toHaveBeenCalledWith({
         userUuid,
         uuid,
       });
@@ -69,12 +162,343 @@ describe('CodeService 단위 테스트', () => {
 
     it('코드 템플릿이 없으면 NotFoundCodeTemplateException을 던진다', async () => {
       // Given
-      (mockCodeRepository.getCodeTemplate as jest.Mock).mockResolvedValue(null);
+      repository.getCodeTemplate.mockResolvedValue(null as never);
 
       // When & Then
       await expect(service.getCodeTemplate({ userUuid, uuid })).rejects.toThrow(
         NotFoundCodeTemplateException,
       );
+    });
+  });
+
+  describe('createCodeTemplate', () => {
+    const userUuid = 'user-uuid-1';
+
+    it('템플릿을 생성하고 반환한다', async () => {
+      // Given
+      const dto = {
+        userUuid,
+        content: 'code',
+        description: '설명',
+        name: '새 템플릿',
+        language: 'JAVA' as const,
+        isDefault: false,
+      };
+      const mockCreated = { uuid: 'new-uuid', ...dto };
+      repository.selectTotalCodeTemplateCount.mockResolvedValue(0);
+      repository.createCodeTemplate.mockResolvedValue(mockCreated as never);
+
+      // When
+      const result = await service.createCodeTemplate(dto as never);
+
+      // Then
+      expect(result).toEqual(mockCreated);
+      expect(repository.createCodeTemplate).toHaveBeenCalledWith({
+        userUuid,
+        content: 'code',
+        description: '설명',
+        name: '새 템플릿',
+        language: 'JAVA',
+      });
+    });
+
+    it('isDefault가 true이면 setDefaultCodeTemplate을 호출한다', async () => {
+      // Given
+      const dto = {
+        userUuid,
+        content: 'code',
+        description: '설명',
+        name: '기본 템플릿',
+        language: 'JAVA' as const,
+        isDefault: true,
+      };
+      const mockCreated = { uuid: 'new-uuid', ...dto };
+      repository.selectTotalCodeTemplateCount.mockResolvedValue(0);
+      repository.createCodeTemplate.mockResolvedValue(mockCreated as never);
+      repository.getCodeTemplateNo.mockResolvedValue(1);
+      repository.upsertCodeDefaultTemplate.mockResolvedValue(undefined as never);
+
+      // When
+      await service.createCodeTemplate(dto as never);
+
+      // Then
+      expect(repository.getCodeTemplateNo).toHaveBeenCalledWith({
+        uuid: 'new-uuid',
+        userUuid,
+      });
+      expect(repository.upsertCodeDefaultTemplate).toHaveBeenCalled();
+    });
+
+    it('템플릿 개수가 MAX_CODE_TEMPLATE_COUNT 이상이면 CodeTemplateLimitExceededException을 던진다', async () => {
+      // Given
+      const dto = {
+        userUuid,
+        content: 'code',
+        name: '초과 템플릿',
+        language: 'JAVA' as const,
+        isDefault: false,
+      };
+      repository.selectTotalCodeTemplateCount.mockResolvedValue(
+        MAX_CODE_TEMPLATE_COUNT,
+      );
+
+      // When & Then
+      await expect(service.createCodeTemplate(dto as never)).rejects.toThrow(
+        CodeTemplateLimitExceededException,
+      );
+    });
+  });
+
+  describe('updateCodeTemplate', () => {
+    const userUuid = 'user-uuid-1';
+    const uuid = 'template-uuid-1';
+
+    it('템플릿을 수정하고 반환한다', async () => {
+      // Given
+      const dto = {
+        userUuid,
+        uuid,
+        content: 'updated code',
+        description: '수정 설명',
+        name: '수정 템플릿',
+        language: 'PYTHON' as const,
+        isDefault: false,
+      };
+      repository.getCodeTemplateNo.mockResolvedValue(1);
+      const mockUpdated = { ...dto };
+      repository.updateCodeTempltae.mockResolvedValue(mockUpdated as never);
+
+      // When
+      const result = await service.updateCodeTemplate(dto as never);
+
+      // Then
+      expect(result).toEqual(mockUpdated);
+      expect(repository.updateCodeTempltae).toHaveBeenCalledWith({
+        userUuid,
+        content: 'updated code',
+        description: '수정 설명',
+        name: '수정 템플릿',
+        language: 'PYTHON',
+        no: 1,
+      });
+    });
+
+    it('존재하지 않는 템플릿이면 NotFoundCodeTemplateException을 던진다', async () => {
+      // Given
+      const dto = {
+        userUuid,
+        uuid,
+        content: 'code',
+        name: '없는 템플릿',
+        language: 'JAVA' as const,
+        isDefault: false,
+      };
+      repository.getCodeTemplateNo.mockResolvedValue(null as never);
+
+      // When & Then
+      await expect(service.updateCodeTemplate(dto as never)).rejects.toThrow(
+        NotFoundCodeTemplateException,
+      );
+    });
+
+    it('isDefault가 true이면 setDefaultCodeTemplate을 호출한다', async () => {
+      // Given
+      const dto = {
+        userUuid,
+        uuid,
+        content: 'code',
+        description: '설명',
+        name: '기본 설정',
+        language: 'JAVA' as const,
+        isDefault: true,
+      };
+      repository.getCodeTemplateNo.mockResolvedValueOnce(1);
+      const mockUpdated = { ...dto };
+      repository.updateCodeTempltae.mockResolvedValue(mockUpdated as never);
+      repository.getCodeTemplateNo.mockResolvedValueOnce(1);
+      repository.upsertCodeDefaultTemplate.mockResolvedValue(undefined as never);
+
+      // When
+      await service.updateCodeTemplate(dto as never);
+
+      // Then
+      expect(repository.upsertCodeDefaultTemplate).toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteCodeTemplate', () => {
+    const userUuid = 'user-uuid-1';
+    const uuid = 'template-uuid-1';
+
+    it('템플릿을 삭제한다', async () => {
+      // Given
+      repository.getCodeTemplateNo.mockResolvedValue(1);
+      repository.deleteCodeTemplate.mockResolvedValue(undefined as never);
+
+      // When
+      await service.deleteCodeTemplate({ uuid, userUuid });
+
+      // Then
+      expect(repository.getCodeTemplateNo).toHaveBeenCalledWith({ uuid, userUuid });
+      expect(repository.deleteCodeTemplate).toHaveBeenCalledWith({ no: 1 });
+    });
+
+    it('존재하지 않는 템플릿이면 NotFoundCodeTemplateException을 던진다', async () => {
+      // Given
+      repository.getCodeTemplateNo.mockResolvedValue(null as never);
+
+      // When & Then
+      await expect(
+        service.deleteCodeTemplate({ uuid, userUuid }),
+      ).rejects.toThrow(NotFoundCodeTemplateException);
+    });
+  });
+
+  describe('setDefaultCodeTemplate', () => {
+    const userUuid = 'user-uuid-1';
+
+    it('기본 템플릿을 설정한다', async () => {
+      // Given
+      const dto = { userUuid, uuid: 'template-uuid-1', language: 'JAVA' as const };
+      repository.getCodeTemplateNo.mockResolvedValue(1);
+      repository.upsertCodeDefaultTemplate.mockResolvedValue(undefined as never);
+
+      // When
+      await service.setDefaultCodeTemplate(dto as never);
+
+      // Then
+      expect(repository.getCodeTemplateNo).toHaveBeenCalledWith({
+        uuid: 'template-uuid-1',
+        userUuid,
+      });
+      expect(repository.upsertCodeDefaultTemplate).toHaveBeenCalledWith({
+        userUuid,
+        language: 'JAVA',
+        codeTemplateNo: 1,
+      });
+    });
+
+    it('uuid가 없으면 NotFoundCodeTemplateException을 던진다', async () => {
+      // Given
+      const dto = { userUuid, uuid: '', language: 'JAVA' as const };
+
+      // When & Then
+      await expect(
+        service.setDefaultCodeTemplate(dto as never),
+      ).rejects.toThrow(NotFoundCodeTemplateException);
+    });
+
+    it('템플릿이 존재하지 않으면 NotFoundCodeTemplateException을 던진다', async () => {
+      // Given
+      const dto = { userUuid, uuid: 'non-existent', language: 'JAVA' as const };
+      repository.getCodeTemplateNo.mockResolvedValue(null as never);
+
+      // When & Then
+      await expect(
+        service.setDefaultCodeTemplate(dto as never),
+      ).rejects.toThrow(NotFoundCodeTemplateException);
+    });
+  });
+
+  describe('problemUuidToProblemNo', () => {
+    const problemUuid = 'problem-uuid-1';
+
+    it('Redis에 캐시가 있으면 캐시된 값을 반환한다', async () => {
+      // Given
+      redisService.get.mockResolvedValue('42');
+
+      // When
+      const result = await service.problemUuidToProblemNo(problemUuid);
+
+      // Then
+      expect(result).toBe(42);
+      expect(redisService.get).toHaveBeenCalledWith(`problemUuid_${problemUuid}`);
+      expect(repository.problemUuidToProblemNo).not.toHaveBeenCalled();
+    });
+
+    it('Redis 미스 시 DB 조회 후 캐시에 저장하고 반환한다', async () => {
+      // Given
+      redisService.get.mockResolvedValue(null);
+      repository.problemUuidToProblemNo.mockResolvedValue({ no: 99 } as never);
+
+      // When
+      const result = await service.problemUuidToProblemNo(problemUuid);
+
+      // Then
+      expect(result).toBe(99);
+      expect(repository.problemUuidToProblemNo).toHaveBeenCalledWith(problemUuid);
+      expect(redisService.set).toHaveBeenCalledWith(
+        `problemUuid_${problemUuid}`,
+        '99',
+      );
+    });
+
+    it('Redis 미스이고 DB에도 없으면 NotFoundProblemException을 던진다', async () => {
+      // Given
+      redisService.get.mockResolvedValue(null);
+      repository.problemUuidToProblemNo.mockResolvedValue(null as never);
+
+      // When & Then
+      await expect(
+        service.problemUuidToProblemNo(problemUuid),
+      ).rejects.toThrow(NotFoundProblemException);
+    });
+  });
+
+  describe('getProblemCodes', () => {
+    const userUuid = 'user-uuid-1';
+    const problemUuid = 'problem-uuid-1';
+
+    it('문제 코드가 존재하면 반환한다', async () => {
+      // Given
+      const mockCodes = { language: 'JAVA', content: 'code' };
+      repository.getProblemCodes.mockResolvedValue(mockCodes as never);
+
+      // When
+      const result = await service.getProblemCodes({ userUuid, problemUuid });
+
+      // Then
+      expect(result).toEqual(mockCodes);
+      expect(repository.getProblemCodes).toHaveBeenCalledWith({
+        userUuid,
+        problemUuid,
+      });
+    });
+
+    it('문제 코드가 없으면 NotFoundProblemCode를 던진다', async () => {
+      // Given
+      repository.getProblemCodes.mockResolvedValue(null as never);
+
+      // When & Then
+      await expect(
+        service.getProblemCodes({ userUuid, problemUuid }),
+      ).rejects.toThrow(NotFoundProblemCode);
+    });
+  });
+
+  describe('upsertProblemCode', () => {
+    it('repository에 위임한다', async () => {
+      // Given
+      const dto = {
+        userUuid: 'user-uuid-1',
+        problemUuid: 'problem-uuid-1',
+        language: 'JAVA' as const,
+        content: 'code',
+      };
+      const mockResult = { ...dto };
+      repository.upsertProblemCode.mockResolvedValue(mockResult as never);
+
+      // When
+      const result = await service.upsertProblemCode(dto as never);
+
+      // Then
+      expect(result).toEqual(mockResult);
+      expect(repository.upsertProblemCode).toHaveBeenCalledWith({
+        userUuid: 'user-uuid-1',
+        problemUuid: 'problem-uuid-1',
+        language: 'JAVA',
+        content: 'code',
+      });
     });
   });
 });

--- a/src/execute/execute.service.spec.ts
+++ b/src/execute/execute.service.spec.ts
@@ -3,6 +3,7 @@ import { ExecuteService } from './execute.service';
 import bullmqConfig from '../config/bullmqConfig';
 import { AppLogger } from '../logger/app-logger';
 import { EventEmitter2 } from '@nestjs/event-emitter';
+import { RequestRunDto } from './dto/RequestRunDto';
 
 describe('ExecuteService', () => {
   let service: ExecuteService;
@@ -61,21 +62,101 @@ describe('ExecuteService', () => {
   });
 
   describe('run', () => {
+    const dto: RequestRunDto = {
+      id: 'test-job',
+      provider: 'Java',
+      code: 'System.out.println("hello")',
+      inputList: [{ input: '1', seq: '1' }],
+    } as RequestRunDto;
+
     it('queue가 초기화되지 않으면 에러를 반환한다', async () => {
       // Given - onModuleInit을 호출하지 않아 queue가 없음
-      const dto = {
-        jobId: 'test-job',
-        language: 'JAVA',
-        code: 'System.out.println("hello")',
-        inputList: ['1'],
-      };
 
       // When
-      const result = await service.run(dto as never);
+      const result = await service.run(dto);
 
       // Then
       expect(result).toHaveProperty('code', '9999');
       expect(result).toHaveProperty('result');
+    });
+
+    it('정상적으로 실행되면 결과를 반환한다', async () => {
+      // Given
+      const expectedResult = {
+        processTime: 100,
+        memory: 256,
+        code: '0000',
+        result: '성공',
+      };
+      const mockJob = {
+        waitUntilFinished: jest.fn().mockResolvedValue(expectedResult),
+      };
+      const mockQueue = {
+        add: jest.fn().mockResolvedValue(mockJob),
+      };
+      (service as unknown as { queue: unknown }).queue = mockQueue;
+      (service as unknown as { queueEvents: unknown }).queueEvents = {};
+
+      // When
+      const result = await service.run(dto);
+
+      // Then
+      expect(result).toEqual(expectedResult);
+      expect(mockQueue.add).toHaveBeenCalledWith('run', dto, {
+        attempts: 2,
+        removeOnComplete: true,
+        removeOnFail: true,
+      });
+    });
+
+    it('타임아웃이 발생하면 code 9000을 반환한다', async () => {
+      // Given
+      const mockJob = {
+        waitUntilFinished: jest
+          .fn()
+          .mockRejectedValue(new Error('timed out before finishing, id=test')),
+      };
+      const mockQueue = {
+        add: jest.fn().mockResolvedValue(mockJob),
+      };
+      (service as unknown as { queue: unknown }).queue = mockQueue;
+      (service as unknown as { queueEvents: unknown }).queueEvents = {};
+
+      // When
+      const result = await service.run(dto);
+
+      // Then
+      expect(result).toEqual({
+        processTime: 0,
+        memory: 0,
+        code: '9000',
+        result: '시간 초과',
+      });
+    });
+
+    it('기타 에러가 발생하면 code 9999를 반환한다', async () => {
+      // Given
+      const mockJob = {
+        waitUntilFinished: jest
+          .fn()
+          .mockRejectedValue(new Error('unexpected error')),
+      };
+      const mockQueue = {
+        add: jest.fn().mockResolvedValue(mockJob),
+      };
+      (service as unknown as { queue: unknown }).queue = mockQueue;
+      (service as unknown as { queueEvents: unknown }).queueEvents = {};
+
+      // When
+      const result = await service.run(dto);
+
+      // Then
+      expect(result).toEqual({
+        processTime: 0,
+        memory: 0,
+        code: '9999',
+        result: '예외 오류',
+      });
     });
   });
 });

--- a/src/oauth-v2/oauth-v2.service.spec.ts
+++ b/src/oauth-v2/oauth-v2.service.spec.ts
@@ -95,6 +95,38 @@ describe('OauthV2Service', () => {
       // Then
       expect(result.state).toBe(OAUTH_STATE.CONNECTED_TO_OTHER_ACCOUNT);
     });
+
+    it('비활성 연동이고 같은 유저면 CONNECTED_AND_INACTIVE를 반환한다', async () => {
+      // Given
+      const oauth = { userUuid: 'user-1', isActive: false };
+      repository.findOne.mockResolvedValue(oauth as never);
+
+      // When
+      const result = await service.getOAuthState({
+        id: '123',
+        provider: 'kakao',
+        userUuid: 'user-1',
+      });
+
+      // Then
+      expect(result.state).toBe(OAUTH_STATE.CONNECTED_AND_INACTIVE);
+    });
+
+    it('비활성 연동이고 다른 유저면 DISCONNECTED_FROM_OTHER_ACCOUNT를 반환한다', async () => {
+      // Given
+      const oauth = { userUuid: 'other-user', isActive: false };
+      repository.findOne.mockResolvedValue(oauth as never);
+
+      // When
+      const result = await service.getOAuthState({
+        id: '123',
+        provider: 'kakao',
+        userUuid: 'user-1',
+      });
+
+      // Then
+      expect(result.state).toBe(OAUTH_STATE.DISCONNECTED_FROM_OTHER_ACCOUNT);
+    });
   });
 
   describe('registerOrLogin', () => {
@@ -138,6 +170,27 @@ describe('OauthV2Service', () => {
       );
       expect(result).toEqual(mockTokens);
     });
+
+    it('비활성 OAuth가 존재하면 활성화 후 로그인한다', async () => {
+      // Given
+      const oauth = { userUuid: 'inactive-uuid', isActive: false };
+      repository.findOne.mockResolvedValue(oauth as never);
+
+      // When
+      const result = await service.registerOrLogin(params);
+
+      // Then
+      expect(repository.updateUserOAuth).toHaveBeenCalledWith({
+        id: '123',
+        provider: 'kakao',
+        userUuid: 'inactive-uuid',
+        isActive: true,
+      });
+      expect(authV2Service.login).toHaveBeenCalledWith(
+        expect.objectContaining({ userUuid: 'inactive-uuid' }),
+      );
+      expect(result).toEqual(mockTokens);
+    });
   });
 
   describe('connectOAuthProvider', () => {
@@ -154,9 +207,20 @@ describe('OauthV2Service', () => {
       expect(repository.createUserOAuth).toHaveBeenCalledWith(params);
     });
 
-    it('다른 계정에 활성 연동이면 OAuthConflictException을 던진다', async () => {
+    it('활성 OAuth가 존재하면 OAuthConflictException을 던진다', async () => {
       // Given
       const oauth = { userUuid: 'other-user', isActive: true };
+      repository.findOne.mockResolvedValue(oauth as never);
+
+      // When & Then
+      await expect(service.connectOAuthProvider(params)).rejects.toThrow(
+        OAuthConflictException,
+      );
+    });
+
+    it('비활성 OAuth가 존재하면 OAuthConflictException을 던진다', async () => {
+      // Given
+      const oauth = { userUuid: 'other-user', isActive: false };
       repository.findOne.mockResolvedValue(oauth as never);
 
       // When & Then


### PR DESCRIPTION
## 작업 내용
- [x] code.service.spec.ts — 전체 public 메서드 테스트 추가 (Redis 캐시, 템플릿 CRUD, 개수 제한 등)
- [x] oauth-v2.service.spec.ts — getOAuthState 누락 상태 분기 및 registerOrLogin 비활성 OAuth 시나리오 추가
- [x] execute.service.spec.ts — Queue mock 주입하여 정상/타임아웃/에러 분기 테스트

## 테스트
- [x] pnpm test 전체 통과 (20 suites, 169 tests)

## 관련 이슈
- ALGOGO-50