### PR TITLE
[ALGOGO-51] refactor: 메서드 오타 수정 및 에러코드/클래스명 일관성 통일

### DIFF
--- a/src/code/code.repository.ts
+++ b/src/code/code.repository.ts
@@ -222,7 +222,7 @@ export class CodeRepository {
     return codeTemplate;
   }
 
-  async updateCodeTempltae({
+  async updateCodeTemplate({
     userUuid,
     content,
     language,

--- a/src/code/code.service.spec.ts
+++ b/src/code/code.service.spec.ts
@@ -7,7 +7,7 @@ import { NotFoundCodeSettingException } from './errors/NotFoundCodeSettingExcept
 import { NotFoundCodeTemplateException } from './errors/NotFoundCodeTemplateException';
 import { CodeTemplateLimitExceededException } from './errors/CodeTemplateLimitExceededException';
 import { NotFoundProblemException } from './errors/NotFoundProblemException';
-import { NotFoundProblemCode } from './errors/NotFoundProblemCode';
+import { NotFoundProblemCodeException } from './errors/NotFoundProblemCodeException';
 import { MAX_CODE_TEMPLATE_COUNT } from './constants';
 
 describe('CodeService 단위 테스트', () => {
@@ -23,7 +23,7 @@ describe('CodeService 단위 테스트', () => {
     createCodeTemplate: jest.fn(),
     selectTotalCodeTemplateCount: jest.fn(),
     getCodeTemplateNo: jest.fn(),
-    updateCodeTempltae: jest.fn(),
+    updateCodeTemplate: jest.fn(),
     deleteCodeTemplate: jest.fn(),
     upsertCodeDefaultTemplate: jest.fn(),
     problemUuidToProblemNo: jest.fn(),
@@ -266,14 +266,14 @@ describe('CodeService 단위 테스트', () => {
       };
       repository.getCodeTemplateNo.mockResolvedValue(1);
       const mockUpdated = { ...dto };
-      repository.updateCodeTempltae.mockResolvedValue(mockUpdated as never);
+      repository.updateCodeTemplate.mockResolvedValue(mockUpdated as never);
 
       // When
       const result = await service.updateCodeTemplate(dto as never);
 
       // Then
       expect(result).toEqual(mockUpdated);
-      expect(repository.updateCodeTempltae).toHaveBeenCalledWith({
+      expect(repository.updateCodeTemplate).toHaveBeenCalledWith({
         userUuid,
         content: 'updated code',
         description: '수정 설명',
@@ -314,7 +314,7 @@ describe('CodeService 단위 테스트', () => {
       };
       repository.getCodeTemplateNo.mockResolvedValueOnce(1);
       const mockUpdated = { ...dto };
-      repository.updateCodeTempltae.mockResolvedValue(mockUpdated as never);
+      repository.updateCodeTemplate.mockResolvedValue(mockUpdated as never);
       repository.getCodeTemplateNo.mockResolvedValueOnce(1);
       repository.upsertCodeDefaultTemplate.mockResolvedValue(undefined as never);
 
@@ -465,14 +465,14 @@ describe('CodeService 단위 테스트', () => {
       });
     });
 
-    it('문제 코드가 없으면 NotFoundProblemCode를 던진다', async () => {
+    it('문제 코드가 없으면 NotFoundProblemCodeException를 던진다', async () => {
       // Given
       repository.getProblemCodes.mockResolvedValue(null as never);
 
       // When & Then
       await expect(
         service.getProblemCodes({ userUuid, problemUuid }),
-      ).rejects.toThrow(NotFoundProblemCode);
+      ).rejects.toThrow(NotFoundProblemCodeException);
     });
   });
 

--- a/src/code/code.service.ts
+++ b/src/code/code.service.ts
@@ -10,7 +10,7 @@ import { CodeTemplateLimitExceededException } from './errors/CodeTemplateLimitEx
 import RequestUpsertCodeTemplateDto from './dto/RequestUpdateCodeTemplateDto';
 import RequestCreateCodeTemplateDto from './dto/RequestCreateCodeTemplateDto';
 import { NotFoundProblemException } from './errors/NotFoundProblemException';
-import { NotFoundProblemCode } from './errors/NotFoundProblemCode';
+import { NotFoundProblemCodeException } from './errors/NotFoundProblemCodeException';
 import { RedisService } from '../redis/redis.service';
 import { MAX_CODE_TEMPLATE_COUNT } from './constants';
 import RequestUpsertProblemCodeDto from './dto/RequestUpsertProblemCodeDto';
@@ -117,7 +117,7 @@ export class CodeService {
       throw new NotFoundCodeTemplateException();
     }
 
-    const codeTemplate = await this.codeRepository.updateCodeTempltae({
+    const codeTemplate = await this.codeRepository.updateCodeTemplate({
       userUuid,
       content,
       description,
@@ -209,7 +209,7 @@ export class CodeService {
     });
 
     if (!problemCodes) {
-      throw new NotFoundProblemCode();
+      throw new NotFoundProblemCodeException();
     }
 
     return problemCodes;

--- a/src/code/errors/CodeTemplateLimitExceededException.ts
+++ b/src/code/errors/CodeTemplateLimitExceededException.ts
@@ -3,7 +3,7 @@ import { CustomConflictException } from '../../common/errors/CustomConflictExcep
 export class CodeTemplateLimitExceededException extends CustomConflictException {
   constructor() {
     super({
-      code: 'C9000',
+      code: 'CODE_TEMPLATE_LIMIT_EXCEEDED',
       message: '설정가능한 코드 템플릿 갯수를 초과하였습니다.',
     });
   }

--- a/src/code/errors/NotFoundCodeSettingException.ts
+++ b/src/code/errors/NotFoundCodeSettingException.ts
@@ -3,7 +3,7 @@ import { CustomNotFoundException } from '../../common/errors/CustomNotFoundExcep
 export class NotFoundCodeSettingException extends CustomNotFoundException {
   constructor() {
     super({
-      code: 'NOT_FOUND',
+      code: 'CODE_SETTING_NOT_FOUND',
       message: '코드 설정을 찾을 수없습니다.',
     });
   }

--- a/src/code/errors/NotFoundCodeTemplateException.ts
+++ b/src/code/errors/NotFoundCodeTemplateException.ts
@@ -3,7 +3,7 @@ import { CustomNotFoundException } from '../../common/errors/CustomNotFoundExcep
 export class NotFoundCodeTemplateException extends CustomNotFoundException {
   constructor() {
     super({
-      code: 'NOT_FOUND',
+      code: 'CODE_TEMPLATE_NOT_FOUND',
       message: '코드 템플릿을 찾을 수없습니다.',
     });
   }

--- a/src/code/errors/NotFoundProblemCodeException.ts
+++ b/src/code/errors/NotFoundProblemCodeException.ts
@@ -1,9 +1,9 @@
 import { CustomNotFoundException } from '../../common/errors/CustomNotFoundException';
 
-export class NotFoundProblemCode extends CustomNotFoundException {
+export class NotFoundProblemCodeException extends CustomNotFoundException {
   constructor() {
     super({
-      code: 'NOT_FOUND_CODE',
+      code: 'PROBLEM_CODE_NOT_FOUND',
       message: '저장된 코드가 없습니다.',
     });
   }

--- a/src/problems-v2/problems-v2.repository.ts
+++ b/src/problems-v2/problems-v2.repository.ts
@@ -13,7 +13,7 @@ import { UserProblemState } from '../common/types/user.type';
 export class ProblemsV2Repository {
   constructor(private readonly prismaService: PrismaService) {}
 
-  async getProblemSumamryByTitle(
+  async getProblemSummaryByTitle(
     dto: InquiryProblemsSummaryDto & { userUuid?: string },
   ) {
     const { pageNo, pageSize, sort, levelList, typeList, title, states } = dto;

--- a/src/problems-v2/problems-v2.service.spec.ts
+++ b/src/problems-v2/problems-v2.service.spec.ts
@@ -11,7 +11,7 @@ describe('ProblemsV2Service', () => {
 
   beforeEach(async () => {
     const mockRepository = {
-      getProblemSumamryByTitle: jest.fn(),
+      getProblemSummaryByTitle: jest.fn(),
       getProblemsSummary: jest.fn(),
       getProblem: jest.fn(),
       getTodayProblems: jest.fn(),
@@ -53,7 +53,7 @@ describe('ProblemsV2Service', () => {
 
         // Then
         expect(repository.getProblemsSummary).toHaveBeenCalledWith(dto);
-        expect(repository.getProblemSumamryByTitle).not.toHaveBeenCalled();
+        expect(repository.getProblemSummaryByTitle).not.toHaveBeenCalled();
       });
 
       it('제목이 1글자일 때 일반 검색을 사용해야 함', async () => {
@@ -71,7 +71,7 @@ describe('ProblemsV2Service', () => {
 
         // Then
         expect(repository.getProblemsSummary).toHaveBeenCalledWith(dto);
-        expect(repository.getProblemSumamryByTitle).not.toHaveBeenCalled();
+        expect(repository.getProblemSummaryByTitle).not.toHaveBeenCalled();
       });
 
       it('빈 문자열 제목일 때 일반 검색을 사용해야 함', async () => {
@@ -89,7 +89,7 @@ describe('ProblemsV2Service', () => {
 
         // Then
         expect(repository.getProblemsSummary).toHaveBeenCalledWith(dto);
-        expect(repository.getProblemSumamryByTitle).not.toHaveBeenCalled();
+        expect(repository.getProblemSummaryByTitle).not.toHaveBeenCalled();
       });
 
       it('특수문자가 포함된 제목일 때 일반 검색을 사용해야 함 (+)', async () => {
@@ -107,7 +107,7 @@ describe('ProblemsV2Service', () => {
 
         // Then
         expect(repository.getProblemsSummary).toHaveBeenCalledWith(dto);
-        expect(repository.getProblemSumamryByTitle).not.toHaveBeenCalled();
+        expect(repository.getProblemSummaryByTitle).not.toHaveBeenCalled();
       });
 
       it('모든 특수문자가 포함된 제목일 때 일반 검색을 사용해야 함', async () => {
@@ -125,7 +125,7 @@ describe('ProblemsV2Service', () => {
 
         // Then
         expect(repository.getProblemsSummary).toHaveBeenCalledWith(dto);
-        expect(repository.getProblemSumamryByTitle).not.toHaveBeenCalled();
+        expect(repository.getProblemSummaryByTitle).not.toHaveBeenCalled();
       });
 
       it('정상적인 제목일 때 N-gram 검색을 사용해야 함', async () => {
@@ -136,13 +136,13 @@ describe('ProblemsV2Service', () => {
           pageSize: 10,
           sort: PROBLEM_SORT.DEFAULT,
         } as any;
-        repository.getProblemSumamryByTitle.mockResolvedValue({} as any);
+        repository.getProblemSummaryByTitle.mockResolvedValue({} as any);
 
         // When
         await service.getProblemsSummary(dto);
 
         // Then
-        expect(repository.getProblemSumamryByTitle).toHaveBeenCalledWith(dto);
+        expect(repository.getProblemSummaryByTitle).toHaveBeenCalledWith(dto);
         expect(repository.getProblemsSummary).not.toHaveBeenCalled();
       });
 
@@ -154,13 +154,13 @@ describe('ProblemsV2Service', () => {
           pageSize: 10,
           sort: PROBLEM_SORT.DEFAULT,
         } as any;
-        repository.getProblemSumamryByTitle.mockResolvedValue({} as any);
+        repository.getProblemSummaryByTitle.mockResolvedValue({} as any);
 
         // When
         await service.getProblemsSummary(dto);
 
         // Then
-        expect(repository.getProblemSumamryByTitle).toHaveBeenCalledWith(dto);
+        expect(repository.getProblemSummaryByTitle).toHaveBeenCalledWith(dto);
         expect(repository.getProblemsSummary).not.toHaveBeenCalled();
       });
     });
@@ -179,7 +179,7 @@ describe('ProblemsV2Service', () => {
         pageNo: 1,
         pageSize: 10,
       };
-      repository.getProblemSumamryByTitle.mockResolvedValue(
+      repository.getProblemSummaryByTitle.mockResolvedValue(
         expectedResult as any,
       );
 

--- a/src/problems-v2/problems-v2.service.ts
+++ b/src/problems-v2/problems-v2.service.ts
@@ -27,7 +27,7 @@ export class ProblemsV2Service {
     const canNgramSearch = hasTitle && title.length > 1 && !hasSpecial;
 
     if (canNgramSearch) {
-      return this.problemsV2Repository.getProblemSumamryByTitle(dto);
+      return this.problemsV2Repository.getProblemSummaryByTitle(dto);
     }
 
     return this.problemsV2Repository.getProblemsSummary(dto);


### PR DESCRIPTION
## 작업 내용
- [x] 메서드 오타 수정: updateCodeTempltae → updateCodeTemplate
- [x] 메서드 오타 수정: getProblemSumamryByTitle → getProblemSummaryByTitle
- [x] 에러코드 DOMAIN_ACTION 패턴 통일 (NOT_FOUND → CODE_SETTING_NOT_FOUND 등 4건)
- [x] 클래스명 Exception 접미사 통일: NotFoundProblemCode → NotFoundProblemCodeException

## 테스트
- [x] pnpm build 통과
- [x] pnpm test 전체 통과 (20 suites, 169 tests)

## 관련 이슈
- ALGOGO-51