### PR TITLE
[ALGOGO-52] fix: Grafana Cloud 연동을 위한 모듈 초기화 순서 수정

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -58,7 +58,28 @@ import { createKeyv } from '@keyv/redis';
 
 @Module({
   imports: [
+    ConfigModule.forRoot({
+      envFilePath: [`.${process.env.NODE_ENV ?? 'production'}.env`],
+      load: [
+        appConfig,
+        s3Config,
+        googleOAuthConfig,
+        kakaoOAuthConfig,
+        githubOAuthConfig,
+        redisConfig,
+        jwtConfig,
+        encryptConfig,
+        bullmqConfig,
+        wsConfig,
+        LoggerConfig,
+        lokiConfig,
+        tempoConfig,
+      ],
+      isGlobal: true,
+      validationSchema,
+    }),
     ClsModule.forRoot({
+      global: true,
       middleware: {
         mount: true,
         setup: (cls, req) => {
@@ -100,9 +121,8 @@ import { createKeyv } from '@keyv/redis';
                   ? `${loki.username}:${loki.password}`
                   : undefined,
               labels: { app: 'algogo' },
-              json: true,
-              format: winston.format.json(),
-              replaceTimestamp: true,
+              batching: true,
+              interval: 5,
               onConnectionError: (err: Error) =>
                 process.stderr.write(`Loki connection error: ${err.message}\n`),
             }),
@@ -112,26 +132,6 @@ import { createKeyv } from '@keyv/redis';
         return { transports };
       },
       inject: [lokiConfig.KEY],
-    }),
-    ConfigModule.forRoot({
-      envFilePath: [`.${process.env.NODE_ENV ?? 'production'}.env`],
-      load: [
-        appConfig,
-        s3Config,
-        googleOAuthConfig,
-        kakaoOAuthConfig,
-        githubOAuthConfig,
-        redisConfig,
-        jwtConfig,
-        encryptConfig,
-        bullmqConfig,
-        wsConfig,
-        LoggerConfig,
-        lokiConfig,
-        tempoConfig,
-      ],
-      isGlobal: true,
-      validationSchema,
     }),
     CacheModule.registerAsync({
       imports: [ConfigModule],

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ import { ValidationPipe } from '@nestjs/common';
 import * as requestIp from 'request-ip';
 import * as cookieParser from 'cookie-parser';
 import helmet from 'helmet';
-import compression from 'compression';
+import * as compression from 'compression';
 import { RedisIoAdapter } from './redis/redis.io.adapter';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 


### PR DESCRIPTION
## 작업 내용
- [x] ConfigModule.forRoot을 imports 최상단으로 이동 (WinstonModule이 env 로드 후 lokiConfig 접근)
- [x] ClsModule.forRoot에 global: true 추가 (LoggerModule의 AppLogger가 ClsService 접근 가능)
- [x] winston-loki 6.x 호환 설정: batching: true, interval: 5 추가, 비호환 옵션 제거
- [x] compression import ESM 호환 수정

## 테스트
- [x] pnpm build 통과
- [x] pnpm test 전체 통과 (20 suites, 169 tests)

## 관련 이슈
- ALGOGO-52