### PR TITLE
[ALGOGO-58] test: 유저 API E2E 테스트 작성

### DIFF
--- a/test/me.e2e-spec.ts
+++ b/test/me.e2e-spec.ts
@@ -1,0 +1,201 @@
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { createTestApp, closeTestApp } from './helpers/setup';
+import { getAccessToken, createAuthHeaders } from './helpers/auth';
+import { seedTestUser, cleanDatabase } from './helpers/seed';
+import { PrismaService } from '../src/prisma/prisma.service';
+import { JwtService } from '../src/jwt/jwt.service';
+
+describe('Me E2E', () => {
+  let app: INestApplication;
+  let prisma: PrismaService;
+
+  beforeAll(async () => {
+    const { app: testApp } = await createTestApp();
+    app = testApp;
+    prisma = app.get(PrismaService);
+  });
+
+  afterAll(async () => {
+    await closeTestApp(app);
+  });
+
+  afterEach(async () => {
+    await cleanDatabase(prisma);
+  });
+
+  describe('GET /api/v1/me', () => {
+    it('유효한 토큰과 정상 유저로 200과 내 정보를 반환한다', async () => {
+      // Given
+      const user = await seedTestUser(prisma, {
+        name: 'test-user',
+        email: 'me@test.com',
+      });
+      const accessToken = await getAccessToken(app, {
+        sub: user.uuid,
+        roles: [],
+      });
+
+      // When
+      const res = await request(app.getHttpServer())
+        .get('/api/v1/me')
+        .set(createAuthHeaders(accessToken))
+        .expect(200);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 200,
+        errorCode: '0000',
+        errorMessage: '',
+      });
+      expect(res.body.data).toMatchObject({
+        uuid: user.uuid,
+        name: 'test-user',
+        email: 'me@test.com',
+        profilePhoto: '',
+      });
+      expect(Array.isArray(res.body.data.socialList)).toBe(true);
+      expect(Array.isArray(res.body.data.oauthList)).toBe(true);
+    });
+
+    it('토큰이 없으면 401 JWT_MISSING 을 반환한다', async () => {
+      // When
+      const res = await request(app.getHttpServer())
+        .get('/api/v1/me')
+        .expect(401);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 401,
+        errorCode: 'JWT_MISSING',
+      });
+    });
+
+    it('만료된 토큰이면 401 JWT_EXPIRED 를 반환한다', async () => {
+      // Given
+      const user = await seedTestUser(prisma);
+      const jwtService = app.get(JwtService);
+      const expiredToken = await jwtService.sign(
+        { sub: user.uuid, roles: [] },
+        0,
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 1100));
+
+      // When
+      const res = await request(app.getHttpServer())
+        .get('/api/v1/me')
+        .set(createAuthHeaders(expiredToken))
+        .expect(401);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 401,
+        errorCode: 'JWT_EXPIRED',
+      });
+    });
+
+    it('DB에 없는 UUID 토큰이면 404 USER_NOT_FOUND 를 반환한다', async () => {
+      // Given
+      const nonExistentUuid = '00000000-0000-0000-0000-000000000000';
+      const accessToken = await getAccessToken(app, {
+        sub: nonExistentUuid,
+        roles: [],
+      });
+
+      // When
+      const res = await request(app.getHttpServer())
+        .get('/api/v1/me')
+        .set(createAuthHeaders(accessToken))
+        .expect(404);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 404,
+        errorCode: 'USER_NOT_FOUND',
+      });
+    });
+
+    it('socialList 와 oauthList 가 비어있는 유저는 빈 배열을 반환한다', async () => {
+      // Given
+      const user = await seedTestUser(prisma);
+      const accessToken = await getAccessToken(app, {
+        sub: user.uuid,
+        roles: [],
+      });
+
+      // When
+      const res = await request(app.getHttpServer())
+        .get('/api/v1/me')
+        .set(createAuthHeaders(accessToken))
+        .expect(200);
+
+      // Then
+      expect(res.body.data.socialList).toEqual([]);
+      expect(res.body.data.oauthList).toEqual([]);
+    });
+  });
+
+  describe('PATCH /api/v1/me/profile', () => {
+    it('이름만 변경하면 200과 업데이트된 정보를 반환한다', async () => {
+      // Given
+      const user = await seedTestUser(prisma, { name: 'old-name' });
+      const accessToken = await getAccessToken(app, {
+        sub: user.uuid,
+        roles: [],
+      });
+
+      // When
+      const res = await request(app.getHttpServer())
+        .patch('/api/v1/me/profile')
+        .set(createAuthHeaders(accessToken))
+        .field('name', 'new-name')
+        .expect(200);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 200,
+        errorCode: '0000',
+        errorMessage: '',
+      });
+      expect(res.body.data.name).toBe('new-name');
+      expect(res.body.data.uuid).toBe(user.uuid);
+    });
+
+    it('body 가 비어있으면 200과 기존 정보를 반환한다', async () => {
+      // Given
+      const user = await seedTestUser(prisma, { name: 'keep-name' });
+      const accessToken = await getAccessToken(app, {
+        sub: user.uuid,
+        roles: [],
+      });
+
+      // When
+      const res = await request(app.getHttpServer())
+        .patch('/api/v1/me/profile')
+        .set(createAuthHeaders(accessToken))
+        .expect(200);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 200,
+        errorCode: '0000',
+        errorMessage: '',
+      });
+      expect(res.body.data.name).toBe('keep-name');
+    });
+
+    it('토큰이 없으면 401 JWT_MISSING 을 반환한다', async () => {
+      // When
+      const res = await request(app.getHttpServer())
+        .patch('/api/v1/me/profile')
+        .expect(401);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 401,
+        errorCode: 'JWT_MISSING',
+      });
+    });
+  });
+});

--- a/test/users.e2e-spec.ts
+++ b/test/users.e2e-spec.ts
@@ -1,0 +1,148 @@
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { createTestApp, closeTestApp } from './helpers/setup';
+import { getAccessToken, createAuthHeaders } from './helpers/auth';
+import { seedTestUser, cleanDatabase } from './helpers/seed';
+import { PrismaService } from '../src/prisma/prisma.service';
+
+describe('Users E2E', () => {
+  let app: INestApplication;
+  let prisma: PrismaService;
+
+  beforeAll(async () => {
+    const { app: testApp } = await createTestApp();
+    app = testApp;
+    prisma = app.get(PrismaService);
+  });
+
+  afterAll(async () => {
+    await closeTestApp(app);
+  });
+
+  afterEach(async () => {
+    await cleanDatabase(prisma);
+  });
+
+  describe('GET /users/:uuid', () => {
+    it('존재하는 유저 UUID 로 200과 유저 정보를 반환한다', async () => {
+      // Given
+      const caller = await seedTestUser(prisma);
+      const target = await seedTestUser(prisma, {
+        name: 'target-user',
+        email: 'target@test.com',
+      });
+      const accessToken = await getAccessToken(app, {
+        sub: caller.uuid,
+        roles: [],
+      });
+
+      // When
+      const res = await request(app.getHttpServer())
+        .get(`/users/${target.uuid}`)
+        .set(createAuthHeaders(accessToken))
+        .expect(200);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 200,
+        errorCode: '0000',
+        errorMessage: '',
+      });
+      expect(res.body.data).toMatchObject({
+        uuid: target.uuid,
+        name: 'target-user',
+        email: 'target@test.com',
+        profilePhoto: '',
+      });
+    });
+
+    it('존재하지 않는 UUID 이면 404 USER_NOT_FOUND 를 반환한다', async () => {
+      // Given
+      const caller = await seedTestUser(prisma);
+      const accessToken = await getAccessToken(app, {
+        sub: caller.uuid,
+        roles: [],
+      });
+      const nonExistentUuid = '00000000-0000-0000-0000-000000000000';
+
+      // When
+      const res = await request(app.getHttpServer())
+        .get(`/users/${nonExistentUuid}`)
+        .set(createAuthHeaders(accessToken))
+        .expect(404);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 404,
+        errorCode: 'USER_NOT_FOUND',
+      });
+    });
+
+    it('잘못된 형식의 UUID 이면 404 USER_NOT_FOUND 를 반환한다', async () => {
+      // Given
+      const caller = await seedTestUser(prisma);
+      const accessToken = await getAccessToken(app, {
+        sub: caller.uuid,
+        roles: [],
+      });
+
+      // When
+      const res = await request(app.getHttpServer())
+        .get('/users/not-a-valid-uuid')
+        .set(createAuthHeaders(accessToken))
+        .expect(404);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 404,
+        errorCode: 'USER_NOT_FOUND',
+      });
+    });
+
+    it('토큰이 없으면 401 JWT_MISSING 을 반환한다', async () => {
+      // Given
+      const target = await seedTestUser(prisma);
+
+      // When
+      const res = await request(app.getHttpServer())
+        .get(`/users/${target.uuid}`)
+        .expect(401);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 401,
+        errorCode: 'JWT_MISSING',
+      });
+    });
+
+    it('비활성 유저를 조회해도 200 을 반환한다', async () => {
+      // Given
+      const caller = await seedTestUser(prisma);
+      const inactiveUser = await seedTestUser(prisma, {
+        state: 'INACTIVE',
+        name: 'inactive-user',
+      });
+      const accessToken = await getAccessToken(app, {
+        sub: caller.uuid,
+        roles: [],
+      });
+
+      // When
+      const res = await request(app.getHttpServer())
+        .get(`/users/${inactiveUser.uuid}`)
+        .set(createAuthHeaders(accessToken))
+        .expect(200);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 200,
+        errorCode: '0000',
+        errorMessage: '',
+      });
+      expect(res.body.data).toMatchObject({
+        uuid: inactiveUser.uuid,
+        name: 'inactive-user',
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 작업 내용
- [x] GET /api/v1/me E2E 테스트 (5개 시나리오)
- [x] PATCH /api/v1/me/profile E2E 테스트 (3개 시나리오)
- [x] GET /users/:uuid E2E 테스트 (5개 시나리오)

## 테스트
- [x] pnpm build 성공
- [x] 테스트 코드 컴파일 확인

## 관련 이슈
- ALGOGO-58