### PR TITLE
Release: E2E 테스트 + 보안 취약점 해결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,4 +64,5 @@ report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 .env
 .env2
 /**/*.env
+.test.env
 /**/env/

--- a/.test.env.example
+++ b/.test.env.example
@@ -1,0 +1,56 @@
+NODE_ENV=test
+SERVER_PORT=3002
+FRONTEND_URL=http://localhost:5173
+
+# Database
+DATABASE_URL=mysql://root:YOUR_PASSWORD@localhost:5007/algogo_test
+
+# Redis
+REDIS_HOST=localhost
+REDIS_PORT=6379
+REDIS_PASSWORD=YOUR_REDIS_PASSWORD
+
+# BullMQ
+BULLMQ_HOST=localhost
+BULLMQ_PORT=6379
+BULLMQ_PASSWORD=YOUR_BULLMQ_PASSWORD
+BULLMQ_QUEUE_NAME=execute-test
+
+# S3
+S3_SECRET_KEY=test-secret
+S3_ACCESS_KEY=test-access
+S3_PROBLEM_BUCKET_NAME=test-bucket
+S3_REGION=ap-southeast-2
+S3_ENDPOINT=https://s3.test.local
+
+# Google OAuth
+GOOGLE_OAUTH_CLIENT_ID=test-google-client-id
+GOOGLE_OAUTH_CLIENT_SECRET=test-google-client-secret
+GOOGLE_OAUTH_CALLBACK_URL=http://localhost:3002/oauth/callback/google
+GOOGLE_OAUTH_AUTHORIZATION_URL=https://accounts.google.com/o/oauth2/v2/auth
+GOOGLE_OAUTH_TOKEN_URL=https://oauth2.googleapis.com/token
+
+# Kakao OAuth
+KAKAO_OAUTH_CLIENT_ID=test-kakao-client-id
+KAKAO_OAUTH_CLIENT_SECRET=test-kakao-client-secret
+KAKAO_OAUTH_CALLBACK_URL=http://localhost:3002/oauth/callback/kakao
+KAKAO_OAUTH_AUTHORIZATION_URL=https://kauth.kakao.com/oauth/authorize
+KAKAO_OAUTH_TOKEN_URL=https://kauth.kakao.com/oauth/token
+
+# JWT
+JWT_SECRET=test-jwt-secret-key-for-e2e-testing
+PREV_JWT_SECRET=test-prev-jwt-secret
+JWT_ACCESS_TOKEN_EXPIRES_IN=70
+JWT_REFRESH_TOKEN_EXPIRES_IN=720000
+
+# Encryption
+ENCRYPT_KEY=dGVzdC1lbmNyeXB0LWtleS0zMi1ieXRlcw==
+ENCRYPT_IV=dGVzdC1lbmNyeXB0LWl2LTE2
+ENCRYPT_TAG=TEST_TAG
+PREV_ENCRYPT_KEY=dGVzdC1lbmNyeXB0LWtleS0zMi1ieXRlcw==
+PREV_ENCRYPT_IV=dGVzdC1lbmNyeXB0LWl2LTE2
+PREV_ENCRYPT_TAG=TEST_TAG
+
+# Observability
+LOKI_ENABLED=false
+TEMPO_ENABLED=false

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -31,7 +31,7 @@ export default tseslint.config(
       '@typescript-eslint/explicit-module-boundary-types': 'off',
       '@typescript-eslint/no-explicit-any': 'error',
       '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
-      '@typescript-eslint/ban-types': 'error',
+      '@typescript-eslint/no-unsafe-function-type': 'error',
     },
   },
 );

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./apps/algogo/test/jest-e2e.json",
+    "test:e2e": "jest --config ./test/jest-e2e.json",
     "test:crawler:e2e": "jest --config ./apps/crawler/test/jest-e2e.json"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -150,7 +150,15 @@
       "axios": ">=1.15.0",
       "socket.io-parser": ">=4.2.6",
       "fast-xml-parser": ">=4.5.5",
-      "flatted": ">=3.4.2"
+      "flatted": ">=3.4.2",
+      "form-data": ">=4.0.4",
+      "validator": ">=13.15.22",
+      "minimatch@<4": ">=3.1.3",
+      "minimatch@>=5 <5.1.8": ">=5.1.8",
+      "jws": ">=3.2.3",
+      "qs": ">=6.14.2",
+      "js-yaml@<3.14.2": ">=3.14.2",
+      "@smithy/config-resolver": ">=4.4.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "jest": "^29.7.0",
     "prettier": "^3.6.2",
     "prisma-markdown": "^1.0.9",
+    "socket.io-client": "^4.8.3",
     "source-map-support": "^0.5.21",
     "supertest": "^6.3.4",
     "ts-jest": "^29.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -270,6 +270,9 @@ importers:
       prisma-markdown:
         specifier: ^1.0.9
         version: 1.0.9(@prisma/client@5.22.0(prisma@5.22.0))(prisma@5.22.0)
+      socket.io-client:
+        specifier: ^4.8.3
+        version: 4.8.3
       source-map-support:
         specifier: ^0.5.21
         version: 0.5.21
@@ -3193,6 +3196,9 @@ packages:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
 
+  engine.io-client@6.6.4:
+    resolution: {integrity: sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==}
+
   engine.io-parser@5.2.3:
     resolution: {integrity: sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==}
     engines: {node: '>=10.0.0'}
@@ -4651,6 +4657,10 @@ packages:
   socket.io-adapter@2.5.5:
     resolution: {integrity: sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==}
 
+  socket.io-client@4.8.3:
+    resolution: {integrity: sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==}
+    engines: {node: '>=10.0.0'}
+
   socket.io-parser@4.2.6:
     resolution: {integrity: sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==}
     engines: {node: '>=10.0.0'}
@@ -5097,6 +5107,22 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xmlhttprequest-ssl@2.1.2:
+    resolution: {integrity: sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==}
+    engines: {node: '>=0.4.0'}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -8839,6 +8865,18 @@ snapshots:
 
   encodeurl@2.0.0: {}
 
+  engine.io-client@6.6.4:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+      engine.io-parser: 5.2.3
+      ws: 8.18.3
+      xmlhttprequest-ssl: 2.1.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   engine.io-parser@5.2.3: {}
 
   engine.io@6.6.4:
@@ -10591,6 +10629,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  socket.io-client@4.8.3:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+      engine.io-client: 6.6.4
+      socket.io-parser: 4.2.6
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   socket.io-parser@4.2.6:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
@@ -11046,6 +11095,10 @@ snapshots:
       signal-exit: 3.0.7
 
   ws@8.17.1: {}
+
+  ws@8.18.3: {}
+
+  xmlhttprequest-ssl@2.1.2: {}
 
   xtend@4.0.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,14 @@ overrides:
   socket.io-parser: '>=4.2.6'
   fast-xml-parser: '>=4.5.5'
   flatted: '>=3.4.2'
+  form-data: '>=4.0.4'
+  validator: '>=13.15.22'
+  minimatch@<4: '>=3.1.3'
+  minimatch@>=5 <5.1.8: '>=5.1.8'
+  jws: '>=3.2.3'
+  qs: '>=6.14.2'
+  js-yaml@<3.14.2: '>=3.14.2'
+  '@smithy/config-resolver': '>=4.4.0'
 
 importers:
 
@@ -2032,8 +2040,8 @@ packages:
     resolution: {integrity: sha512-+sKqDBQqb036hh4NPaUiEkYFkTUGYzRsn3EuFhyfQfMy6oGHEUJDurLP9Ufb5dasr/XiAmPNMr6wa9afjQB+Gw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/config-resolver@4.1.4':
-    resolution: {integrity: sha512-prmU+rDddxHOH0oNcwemL+SwnzcG65sBF2yXRO7aeXIn/xTlq2pX7JLVbkBnVLowHLg4/OL4+jBmv9hVrVGS+w==}
+  '@smithy/config-resolver@4.4.14':
+    resolution: {integrity: sha512-N55f8mPEccpzKetUagdvmAy8oohf0J5cuj9jLI1TaSceRlq0pJsIZepY3kmAXAhyxqXPV6hDerDQhqQPKWgAoQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/core@3.6.0':
@@ -2120,12 +2128,20 @@ packages:
     resolution: {integrity: sha512-HGHQr2s59qaU1lrVH6MbLlmOBxadtzTsoO4c+bF5asdgVik3I8o7JIOzoeqWc5MjVa+vD36/LWE0iXKpNqooRw==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/node-config-provider@4.3.13':
+    resolution: {integrity: sha512-iGxQ04DsKXLckbgnX4ipElrOTk+IHgTyu0q0WssZfYhDm9CQWHmu6cOeI5wmWRxpXbBDhIIfXMWz5tPEtcVqbw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/node-http-handler@4.0.6':
     resolution: {integrity: sha512-NqbmSz7AW2rvw4kXhKGrYTiJVDHnMsFnX4i+/FzcZAfbOBauPYs2ekuECkSbtqaxETLLTu9Rl/ex6+I2BKErPA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/property-provider@4.0.4':
     resolution: {integrity: sha512-qHJ2sSgu4FqF4U/5UUp4DhXNmdTrgmoAai6oQiM+c5RZ/sbDwJ12qxB1M6FnP+Tn/ggkPZf9ccn4jqKSINaquw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/property-provider@4.2.13':
+    resolution: {integrity: sha512-bGzUCthxRmezuxkbu9wD33wWg9KX3hJpCXpQ93vVkPrHn9ZW6KNNdY5xAUWNuRCwQ+VyboFuWirG1lZhhkcyRQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/protocol-http@5.1.2':
@@ -2148,12 +2164,20 @@ packages:
     resolution: {integrity: sha512-63X0260LoFBjrHifPDs+nM9tV0VMkOTl4JRMYNuKh/f5PauSjowTfvF3LogfkWdcPoxsA9UjqEOgjeYIbhb7Nw==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/shared-ini-file-loader@4.4.8':
+    resolution: {integrity: sha512-VZCZx2bZasxdqxVgEAhREvDSlkatTPnkdWy1+Kiy8w7kYPBosW0V5IeDwzDUMvWBt56zpK658rx1cOBFOYaPaw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/signature-v4@5.1.2':
     resolution: {integrity: sha512-d3+U/VpX7a60seHziWnVZOHuEgJlclufjkS6zhXvxcJgkJq4UWdH5eOBLzHRMx6gXjsdT9h6lfpmLzbrdupHgQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/smithy-client@4.4.5':
     resolution: {integrity: sha512-+lynZjGuUFJaMdDYSTMnP/uPBBXXukVfrJlP+1U/Dp5SFTEI++w6NMga8DjOENxecOF71V9Z2DllaVDYRnGlkg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.14.0':
+    resolution: {integrity: sha512-OWgntFLW88kx2qvf/c/67Vno1yuXm/f9M7QFAtVkkO29IJXGBIg0ycEaBTH0kvCtwmvZxRujrgP5a86RvsXJAQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/types@4.3.1':
@@ -2188,6 +2212,10 @@ packages:
     resolution: {integrity: sha512-L1RBVzLyfE8OXH+1hsJ8p+acNUSirQnWQ6/EgpchV88G6zGBTDPdXiiExei6Z1wR2RxYvxY/XLw6AMNCCt8H3w==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/util-config-provider@4.2.2':
+    resolution: {integrity: sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/util-defaults-mode-browser@4.0.21':
     resolution: {integrity: sha512-wM0jhTytgXu3wzJoIqpbBAG5U6BwiubZ6QKzSbP7/VbmF1v96xlAbX2Am/mz0Zep0NLvLh84JT0tuZnk3wmYQA==}
     engines: {node: '>=18.0.0'}
@@ -2200,12 +2228,20 @@ packages:
     resolution: {integrity: sha512-YARl3tFL3WgPuLzljRUnrS2ngLiUtkwhQtj8PAL13XZSyUiNLQxwG3fBBq3QXFqGFUXepIN73pINp3y8c2nBmA==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/util-endpoints@3.3.4':
+    resolution: {integrity: sha512-BKoR/ubPp9KNKFxPpg1J28N1+bgu8NGAtJblBP7yHy8yQPBWhIAv9+l92SlQLpolGm71CVO+btB60gTgzT0wog==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/util-hex-encoding@4.0.0':
     resolution: {integrity: sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-middleware@4.0.4':
     resolution: {integrity: sha512-9MLKmkBmf4PRb0ONJikCbCwORACcil6gUWojwARCClT7RmLzF04hUR4WdRprIXal7XVyrddadYNfp2eF3nrvtQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-middleware@4.2.13':
+    resolution: {integrity: sha512-GTooyrlmRTqvUen4eK7/K1p6kryF7bnDfq6XsAbIsf2mo51B/utaH+XThY6dKgNCWzMAaH/+OLmqaBuLhLWRow==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-retry@4.0.6':
@@ -2660,9 +2696,6 @@ packages:
   arg@4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
 
-  argparse@1.0.10:
-    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
-
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -2710,9 +2743,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -2755,12 +2785,6 @@ packages:
 
   bowser@2.11.0:
     resolution: {integrity: sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==}
-
-  brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
-
-  brace-expansion@2.0.2:
-    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
 
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
@@ -2965,9 +2989,6 @@ packages:
   compression@1.8.1:
     resolution: {integrity: sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==}
     engines: {node: '>= 0.8.0'}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   concat-stream@2.0.0:
     resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
@@ -3461,10 +3482,6 @@ packages:
       typescript: '>3.6.0'
       webpack: ^5.11.0
 
-  form-data@4.0.3:
-    resolution: {integrity: sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==}
-    engines: {node: '>= 6'}
-
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
@@ -3877,10 +3894,6 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.14.1:
-    resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
-    hasBin: true
-
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
@@ -3927,14 +3940,8 @@ packages:
     resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
     engines: {node: '>=12', npm: '>=6'}
 
-  jwa@1.4.2:
-    resolution: {integrity: sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==}
-
   jwa@2.0.1:
     resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
-
-  jws@3.2.2:
-    resolution: {integrity: sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==}
 
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
@@ -4116,13 +4123,6 @@ packages:
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
-
-  minimatch@3.1.2:
-    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
-
-  minimatch@5.1.6:
-    resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
-    engines: {node: '>=10'}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -4471,10 +4471,6 @@ packages:
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
-  qs@6.14.0:
-    resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
-    engines: {node: '>=0.6'}
-
   qs@6.15.1:
     resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
     engines: {node: '>=0.6'}
@@ -4682,9 +4678,6 @@ packages:
   source-map@0.7.4:
     resolution: {integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==}
     engines: {node: '>= 8'}
-
-  sprintf-js@1.0.3:
-    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
   stack-trace@0.0.10:
     resolution: {integrity: sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==}
@@ -5015,8 +5008,8 @@ packages:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
 
-  validator@13.15.15:
-    resolution: {integrity: sha512-BgWVbCI72aIQy937xbawcs+hrVaN/CZ2UwutgaJ36hGqRrLNM+f5LUT/YPRbo8IV/ASeFzXszezV+y2+rq3l8A==}
+  validator@13.15.35:
+    resolution: {integrity: sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==}
     engines: {node: '>= 0.10'}
 
   vary@1.1.2:
@@ -5295,7 +5288,7 @@ snapshots:
       '@aws-sdk/util-user-agent-browser': 3.840.0
       '@aws-sdk/util-user-agent-node': 3.840.0
       '@aws-sdk/xml-builder': 3.821.0
-      '@smithy/config-resolver': 4.1.4
+      '@smithy/config-resolver': 4.4.14
       '@smithy/core': 3.6.0
       '@smithy/eventstream-serde-browser': 4.0.4
       '@smithy/eventstream-serde-config-resolver': 4.1.2
@@ -5348,7 +5341,7 @@ snapshots:
       '@aws-sdk/util-endpoints': 3.840.0
       '@aws-sdk/util-user-agent-browser': 3.840.0
       '@aws-sdk/util-user-agent-node': 3.840.0
-      '@smithy/config-resolver': 4.1.4
+      '@smithy/config-resolver': 4.4.14
       '@smithy/core': 3.6.0
       '@smithy/fetch-http-handler': 5.0.4
       '@smithy/hash-node': 4.0.4
@@ -5590,7 +5583,7 @@ snapshots:
       '@aws-sdk/util-endpoints': 3.840.0
       '@aws-sdk/util-user-agent-browser': 3.840.0
       '@aws-sdk/util-user-agent-node': 3.840.0
-      '@smithy/config-resolver': 4.1.4
+      '@smithy/config-resolver': 4.4.14
       '@smithy/core': 3.6.0
       '@smithy/fetch-http-handler': 5.0.4
       '@smithy/hash-node': 4.0.4
@@ -6196,7 +6189,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 3.14.1
+      js-yaml: 4.1.1
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.3': {}
@@ -7498,12 +7491,13 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@smithy/config-resolver@4.1.4':
+  '@smithy/config-resolver@4.4.14':
     dependencies:
-      '@smithy/node-config-provider': 4.1.3
-      '@smithy/types': 4.3.1
-      '@smithy/util-config-provider': 4.0.0
-      '@smithy/util-middleware': 4.0.4
+      '@smithy/node-config-provider': 4.3.13
+      '@smithy/types': 4.14.0
+      '@smithy/util-config-provider': 4.2.2
+      '@smithy/util-endpoints': 3.3.4
+      '@smithy/util-middleware': 4.2.13
       tslib: 2.8.1
 
   '@smithy/core@3.6.0':
@@ -7650,6 +7644,13 @@ snapshots:
       '@smithy/types': 4.3.1
       tslib: 2.8.1
 
+  '@smithy/node-config-provider@4.3.13':
+    dependencies:
+      '@smithy/property-provider': 4.2.13
+      '@smithy/shared-ini-file-loader': 4.4.8
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
   '@smithy/node-http-handler@4.0.6':
     dependencies:
       '@smithy/abort-controller': 4.0.4
@@ -7661,6 +7662,11 @@ snapshots:
   '@smithy/property-provider@4.0.4':
     dependencies:
       '@smithy/types': 4.3.1
+      tslib: 2.8.1
+
+  '@smithy/property-provider@4.2.13':
+    dependencies:
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/protocol-http@5.1.2':
@@ -7688,6 +7694,11 @@ snapshots:
       '@smithy/types': 4.3.1
       tslib: 2.8.1
 
+  '@smithy/shared-ini-file-loader@4.4.8':
+    dependencies:
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
   '@smithy/signature-v4@5.1.2':
     dependencies:
       '@smithy/is-array-buffer': 4.0.0
@@ -7707,6 +7718,10 @@ snapshots:
       '@smithy/protocol-http': 5.1.2
       '@smithy/types': 4.3.1
       '@smithy/util-stream': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/types@4.14.0':
+    dependencies:
       tslib: 2.8.1
 
   '@smithy/types@4.3.1':
@@ -7747,6 +7762,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@smithy/util-config-provider@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
   '@smithy/util-defaults-mode-browser@4.0.21':
     dependencies:
       '@smithy/property-provider': 4.0.4
@@ -7757,7 +7776,7 @@ snapshots:
 
   '@smithy/util-defaults-mode-node@4.0.21':
     dependencies:
-      '@smithy/config-resolver': 4.1.4
+      '@smithy/config-resolver': 4.4.14
       '@smithy/credential-provider-imds': 4.0.6
       '@smithy/node-config-provider': 4.1.3
       '@smithy/property-provider': 4.0.4
@@ -7771,6 +7790,12 @@ snapshots:
       '@smithy/types': 4.3.1
       tslib: 2.8.1
 
+  '@smithy/util-endpoints@3.3.4':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.13
+      '@smithy/types': 4.14.0
+      tslib: 2.8.1
+
   '@smithy/util-hex-encoding@4.0.0':
     dependencies:
       tslib: 2.8.1
@@ -7778,6 +7803,11 @@ snapshots:
   '@smithy/util-middleware@4.0.4':
     dependencies:
       '@smithy/types': 4.3.1
+      tslib: 2.8.1
+
+  '@smithy/util-middleware@4.2.13':
+    dependencies:
+      '@smithy/types': 4.14.0
       tslib: 2.8.1
 
   '@smithy/util-retry@4.0.6':
@@ -8043,7 +8073,7 @@ snapshots:
       '@types/cookiejar': 2.1.5
       '@types/methods': 1.1.4
       '@types/node': 20.19.4
-      form-data: 4.0.3
+      form-data: 4.0.5
 
   '@types/supertest@6.0.3':
     dependencies:
@@ -8337,10 +8367,6 @@ snapshots:
 
   arg@4.1.3: {}
 
-  argparse@1.0.10:
-    dependencies:
-      sprintf-js: 1.0.3
-
   argparse@2.0.1: {}
 
   array-timsort@1.0.3: {}
@@ -8416,8 +8442,6 @@ snapshots:
       babel-plugin-jest-hoist: 29.6.3
       babel-preset-current-node-syntax: 1.1.0(@babel/core@7.28.0)
 
-  balanced-match@1.0.2: {}
-
   balanced-match@4.0.4: {}
 
   base64-js@1.5.1: {}
@@ -8457,15 +8481,6 @@ snapshots:
   boolbase@1.0.0: {}
 
   bowser@2.11.0: {}
-
-  brace-expansion@1.1.12:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
-  brace-expansion@2.0.2:
-    dependencies:
-      balanced-match: 1.0.2
 
   brace-expansion@5.0.5:
     dependencies:
@@ -8583,7 +8598,7 @@ snapshots:
     dependencies:
       '@types/validator': 13.15.2
       libphonenumber-js: 1.12.9
-      validator: 13.15.15
+      validator: 13.15.35
 
   cli-cursor@3.1.0:
     dependencies:
@@ -8675,8 +8690,6 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
-
-  concat-map@0.0.1: {}
 
   concat-stream@2.0.0:
     dependencies:
@@ -9073,7 +9086,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.14.0
+      qs: 6.15.1
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -9142,7 +9155,7 @@ snapshots:
 
   filelist@1.0.4:
     dependencies:
-      minimatch: 5.1.6
+      minimatch: 10.2.5
 
   fill-range@7.1.1:
     dependencies:
@@ -9189,21 +9202,13 @@ snapshots:
       deepmerge: 4.3.1
       fs-extra: 10.1.0
       memfs: 3.5.3
-      minimatch: 3.1.2
+      minimatch: 10.2.5
       node-abort-controller: 3.1.1
       schema-utils: 3.3.0
       semver: 7.7.4
       tapable: 2.2.2
       typescript: 5.9.3
       webpack: 5.106.0
-
-  form-data@4.0.3:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
-      mime-types: 2.1.35
 
   form-data@4.0.5:
     dependencies:
@@ -9222,7 +9227,7 @@ snapshots:
       '@paralleldrive/cuid2': 2.2.2
       dezalgo: 1.0.4
       once: 1.4.0
-      qs: 6.14.0
+      qs: 6.15.1
 
   forwarded-parse@2.1.2: {}
 
@@ -9306,7 +9311,7 @@ snapshots:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.1.2
+      minimatch: 10.2.5
       once: 1.4.0
       path-is-absolute: 1.0.1
 
@@ -9489,7 +9494,7 @@ snapshots:
       async: 3.2.6
       chalk: 4.1.2
       filelist: 1.0.4
-      minimatch: 3.1.2
+      minimatch: 10.2.5
 
   jest-changed-files@29.7.0:
     dependencies:
@@ -9816,11 +9821,6 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.14.1:
-    dependencies:
-      argparse: 1.0.10
-      esprima: 4.0.1
-
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
@@ -9853,7 +9853,7 @@ snapshots:
 
   jsonwebtoken@9.0.2:
     dependencies:
-      jws: 3.2.2
+      jws: 4.0.1
       lodash.includes: 4.3.0
       lodash.isboolean: 3.0.3
       lodash.isinteger: 4.0.4
@@ -9877,21 +9877,10 @@ snapshots:
       ms: 2.1.3
       semver: 7.7.4
 
-  jwa@1.4.2:
-    dependencies:
-      buffer-equal-constant-time: 1.0.1
-      ecdsa-sig-formatter: 1.0.11
-      safe-buffer: 5.2.1
-
   jwa@2.0.1:
     dependencies:
       buffer-equal-constant-time: 1.0.1
       ecdsa-sig-formatter: 1.0.11
-      safe-buffer: 5.2.1
-
-  jws@3.2.2:
-    dependencies:
-      jwa: 1.4.2
       safe-buffer: 5.2.1
 
   jws@4.0.1:
@@ -10038,14 +10027,6 @@ snapshots:
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
-
-  minimatch@3.1.2:
-    dependencies:
-      brace-expansion: 1.1.12
-
-  minimatch@5.1.6:
-    dependencies:
-      brace-expansion: 2.0.2
 
   minimist@1.2.8: {}
 
@@ -10375,10 +10356,6 @@ snapshots:
 
   pure-rand@6.1.0: {}
 
-  qs@6.14.0:
-    dependencies:
-      side-channel: 1.1.0
-
   qs@6.15.1:
     dependencies:
       side-channel: 1.1.0
@@ -10675,8 +10652,6 @@ snapshots:
 
   source-map@0.7.4: {}
 
-  sprintf-js@1.0.3: {}
-
   stack-trace@0.0.10: {}
 
   stack-utils@2.0.6:
@@ -10730,11 +10705,11 @@ snapshots:
       cookiejar: 2.1.4
       debug: 4.4.1
       fast-safe-stringify: 2.1.1
-      form-data: 4.0.3
+      form-data: 4.0.5
       formidable: 2.1.5
       methods: 1.1.2
       mime: 2.6.0
-      qs: 6.14.0
+      qs: 6.15.1
       semver: 7.7.2
     transitivePeerDependencies:
       - supports-color
@@ -10793,7 +10768,7 @@ snapshots:
     dependencies:
       '@istanbuljs/schema': 0.1.3
       glob: 7.2.3
-      minimatch: 3.1.2
+      minimatch: 10.2.5
 
   text-hex@1.0.0: {}
 
@@ -10973,7 +10948,7 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
-  validator@13.15.15: {}
+  validator@13.15.35: {}
 
   vary@1.1.2: {}
 

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -1,24 +1,65 @@
-import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
-import { AppModule } from './../src/app.module';
+import { PrismaService } from '../src/prisma/prisma.service';
+import {
+  createTestApp,
+  closeTestApp,
+  cleanDatabase,
+  seedTestUser,
+  getAccessToken,
+} from './helpers';
 
-describe('AppController (e2e)', () => {
+describe('App (e2e)', () => {
   let app: INestApplication;
 
-  beforeEach(async () => {
-    const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule],
-    }).compile();
-
-    app = moduleFixture.createNestApplication();
-    await app.init();
+  beforeAll(async () => {
+    const testApp = await createTestApp();
+    app = testApp.app;
   });
 
-  it('/ (GET)', () => {
-    return request(app.getHttpServer())
-      .get('/')
-      .expect(200)
-      .expect('Hello World!');
+  afterAll(async () => {
+    const prisma = app.get(PrismaService);
+    await cleanDatabase(prisma);
+    await closeTestApp(app);
+  });
+
+  describe('인프라 검증', () => {
+    it('앱이 정상적으로 시작된다', () => {
+      expect(app).toBeDefined();
+    });
+
+    it('인증 없는 요청은 401을 반환한다', () => {
+      return request(app.getHttpServer())
+        .get('/api/v1/me')
+        .expect(401);
+    });
+
+    it('유효한 토큰으로 인증된 요청이 동작한다', async () => {
+      const prisma = app.get(PrismaService);
+      const user = await seedTestUser(prisma);
+      const token = await getAccessToken(app, {
+        sub: user.uuid,
+        roles: [],
+      });
+
+      const response = await request(app.getHttpServer())
+        .get('/api/v1/me')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+
+      expect(response.body).toHaveProperty('statusCode', 200);
+      expect(response.body).toHaveProperty('errorCode', '0000');
+      expect(response.body).toHaveProperty('data');
+    });
+
+    it('응답 형식이 올바르다 (ResponseInterceptor)', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/api/v1/me')
+        .expect(401);
+
+      expect(response.body).toHaveProperty('statusCode');
+      expect(response.body).toHaveProperty('errorCode');
+      expect(response.body).toHaveProperty('errorMessage');
+    });
   });
 });

--- a/test/auth.e2e-spec.ts
+++ b/test/auth.e2e-spec.ts
@@ -1,0 +1,355 @@
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Cache } from 'cache-manager';
+import { createTestApp, closeTestApp } from './helpers/setup';
+import {
+  getAccessToken,
+  getRefreshToken,
+  createAuthHeaders,
+  createAuthCookies,
+} from './helpers/auth';
+import { seedTestUser, cleanDatabase } from './helpers/seed';
+import { PrismaService } from '../src/prisma/prisma.service';
+import { JwtService } from '../src/jwt/jwt.service';
+
+describe('Auth E2E', () => {
+  let app: INestApplication;
+  let prisma: PrismaService;
+  let cache: Cache;
+
+  const REFRESH_TOKEN_TTL_MS = 7 * 24 * 60 * 60 * 1000 + 10000; // jwtRefreshTokenExpiresIn * 1000 + 10000
+
+  async function loginTestUser(
+    overrides?: Partial<{
+      uuid: string;
+      email: string;
+      name: string;
+      state: string;
+    }>,
+  ) {
+    const user = await seedTestUser(prisma, overrides);
+    const accessToken = await getAccessToken(app, {
+      sub: user.uuid,
+      roles: [],
+    });
+    const refreshToken = await getRefreshToken(app, { sub: user.uuid });
+
+    await cache.set(
+      `${user.uuid}:${refreshToken}`,
+      true,
+      REFRESH_TOKEN_TTL_MS,
+    );
+
+    return { user, accessToken, refreshToken };
+  }
+
+  beforeAll(async () => {
+    const { app: testApp } = await createTestApp();
+    app = testApp;
+    prisma = app.get(PrismaService);
+    cache = app.get<Cache>(CACHE_MANAGER);
+  });
+
+  afterAll(async () => {
+    await closeTestApp(app);
+  });
+
+  afterEach(async () => {
+    await cleanDatabase(prisma);
+  });
+
+  describe('POST /api/v2/auth/refresh', () => {
+    it('유효한 refresh token (쿠키) 으로 새 토큰 쌍을 반환한다', async () => {
+      // Given
+      const { refreshToken } = await loginTestUser();
+
+      // When
+      const res = await request(app.getHttpServer())
+        .post('/api/v2/auth/refresh')
+        .set('Cookie', createAuthCookies('', refreshToken))
+        .expect(200);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 200,
+        errorCode: '0000',
+        errorMessage: '',
+      });
+      expect(res.body.data).toHaveProperty('accessToken');
+      expect(res.body.data).toHaveProperty('refreshToken');
+      expect(typeof res.body.data.accessToken).toBe('string');
+      expect(typeof res.body.data.refreshToken).toBe('string');
+
+      // 쿠키에 새 토큰이 설정되었는지 확인
+      const cookies = res.headers['set-cookie'];
+      expect(cookies).toBeDefined();
+      const cookieStr = Array.isArray(cookies) ? cookies.join('; ') : cookies;
+      expect(cookieStr).toContain('access_token=');
+      expect(cookieStr).toContain('refresh_token=');
+    });
+
+    it('유효한 refresh token (Authorization 헤더) 으로 새 토큰 쌍을 반환한다', async () => {
+      // Given
+      const { refreshToken } = await loginTestUser();
+
+      // When
+      const res = await request(app.getHttpServer())
+        .post('/api/v2/auth/refresh')
+        .set(createAuthHeaders(refreshToken))
+        .expect(200);
+
+      // Then
+      expect(res.body.statusCode).toBe(200);
+      expect(res.body.data).toHaveProperty('accessToken');
+      expect(res.body.data).toHaveProperty('refreshToken');
+    });
+
+    it('refresh token 이 없으면 401 JWT_MISSING 을 반환한다', async () => {
+      // When
+      const res = await request(app.getHttpServer())
+        .post('/api/v2/auth/refresh')
+        .expect(401);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 401,
+        errorCode: 'JWT_MISSING',
+      });
+    });
+
+    it('만료된 refresh token 이면 401 JWT_EXPIRED 를 반환한다', async () => {
+      // Given
+      const user = await seedTestUser(prisma);
+      const jwtService = app.get(JwtService);
+      // expiresIn 0초로 이미 만료된 토큰 생성
+      const expiredToken = await jwtService.sign({ sub: user.uuid }, 0);
+
+      // 즉시 만료되므로 잠시 대기
+      await new Promise((resolve) => setTimeout(resolve, 1100));
+
+      // When
+      const res = await request(app.getHttpServer())
+        .post('/api/v2/auth/refresh')
+        .set('Cookie', `refresh_token=${expiredToken}`)
+        .expect(401);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 401,
+        errorCode: 'JWT_EXPIRED',
+      });
+    });
+
+    it('변조된 refresh token 이면 401 JWT_INVALID 를 반환한다', async () => {
+      // Given
+      const tamperedToken =
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0IiwiaWF0IjoxNjE2MjM5MDIyfQ.invalid_signature';
+
+      // When
+      const res = await request(app.getHttpServer())
+        .post('/api/v2/auth/refresh')
+        .set('Cookie', `refresh_token=${tamperedToken}`)
+        .expect(401);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 401,
+        errorCode: 'JWT_INVALID',
+      });
+    });
+
+    it('유효한 JWT 이지만 Redis 에 없는 refresh token 이면 401 JWT_INVALID 를 반환한다', async () => {
+      // Given
+      const user = await seedTestUser(prisma);
+      const refreshToken = await getRefreshToken(app, { sub: user.uuid });
+      // Redis에 저장하지 않음
+
+      // When
+      const res = await request(app.getHttpServer())
+        .post('/api/v2/auth/refresh')
+        .set('Cookie', `refresh_token=${refreshToken}`)
+        .expect(401);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 401,
+        errorCode: 'JWT_INVALID',
+      });
+    });
+
+    it('유효한 토큰이지만 유저가 삭제되었으면 404 USER_NOT_FOUND 를 반환한다', async () => {
+      // Given
+      const { refreshToken } = await loginTestUser();
+
+      // 유저 삭제
+      await cleanDatabase(prisma);
+
+      // When
+      const res = await request(app.getHttpServer())
+        .post('/api/v2/auth/refresh')
+        .set('Cookie', `refresh_token=${refreshToken}`)
+        .expect(404);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 404,
+        errorCode: 'USER_NOT_FOUND',
+      });
+    });
+
+    it('유효한 토큰이지만 유저가 비활성이면 403 USER_INACTIVE 를 반환한다', async () => {
+      // Given
+      const { refreshToken } = await loginTestUser({ state: 'INACTIVE' });
+
+      // When
+      const res = await request(app.getHttpServer())
+        .post('/api/v2/auth/refresh')
+        .set('Cookie', `refresh_token=${refreshToken}`)
+        .expect(403);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 403,
+        errorCode: 'USER_INACTIVE',
+      });
+    });
+
+    it('refresh 후 이전 refresh token 을 재사용하면 401 JWT_INVALID 를 반환한다 (token rotation)', async () => {
+      // Given
+      const { refreshToken: oldRefreshToken } = await loginTestUser();
+
+      // 첫 번째 refresh 성공
+      await request(app.getHttpServer())
+        .post('/api/v2/auth/refresh')
+        .set('Cookie', `refresh_token=${oldRefreshToken}`)
+        .expect(200);
+
+      // When — 이전 토큰으로 다시 refresh 시도
+      const res = await request(app.getHttpServer())
+        .post('/api/v2/auth/refresh')
+        .set('Cookie', `refresh_token=${oldRefreshToken}`)
+        .expect(401);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 401,
+        errorCode: 'JWT_INVALID',
+      });
+    });
+
+    it('refresh 후 새 토큰으로 다시 refresh 에 성공한다', async () => {
+      // Given
+      const { refreshToken: firstRefreshToken } = await loginTestUser();
+
+      // 첫 번째 refresh
+      const firstRes = await request(app.getHttpServer())
+        .post('/api/v2/auth/refresh')
+        .set('Cookie', `refresh_token=${firstRefreshToken}`)
+        .expect(200);
+
+      const newRefreshToken = firstRes.body.data.refreshToken;
+
+      // 새 refresh token 을 Redis 에 저장 (서비스가 이미 저장하므로 별도 저장 불필요)
+      // When — 새 토큰으로 두 번째 refresh
+      const secondRes = await request(app.getHttpServer())
+        .post('/api/v2/auth/refresh')
+        .set('Cookie', `refresh_token=${newRefreshToken}`)
+        .expect(200);
+
+      // Then
+      expect(secondRes.body.statusCode).toBe(200);
+      expect(secondRes.body.data).toHaveProperty('accessToken');
+      expect(secondRes.body.data).toHaveProperty('refreshToken');
+      expect(secondRes.body.data.refreshToken).not.toBe(newRefreshToken);
+    });
+  });
+
+  describe('POST /api/v2/auth/logout', () => {
+    it('유효한 access token + refresh token 쿠키로 로그아웃에 성공한다', async () => {
+      // Given
+      const { accessToken, refreshToken } = await loginTestUser();
+
+      // When
+      const res = await request(app.getHttpServer())
+        .post('/api/v2/auth/logout')
+        .set('Cookie', createAuthCookies(accessToken, refreshToken))
+        .expect(200);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 200,
+        errorCode: '0000',
+        errorMessage: '',
+      });
+
+      // 쿠키가 클리어되었는지 확인
+      const cookies = res.headers['set-cookie'];
+      expect(cookies).toBeDefined();
+      const cookieStr = Array.isArray(cookies) ? cookies.join('; ') : cookies;
+      expect(cookieStr).toContain('access_token=');
+      expect(cookieStr).toContain('refresh_token=');
+    });
+
+    it('access token 이 없으면 401 JWT_MISSING 을 반환한다', async () => {
+      // When
+      const res = await request(app.getHttpServer())
+        .post('/api/v2/auth/logout')
+        .expect(401);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 401,
+        errorCode: 'JWT_MISSING',
+      });
+    });
+
+    it('만료된 access token 이면 401 JWT_EXPIRED 를 반환한다', async () => {
+      // Given
+      const jwtService = app.get(JwtService);
+      const user = await seedTestUser(prisma);
+      const expiredAccessToken = await jwtService.sign(
+        { sub: user.uuid, roles: [] },
+        0,
+      );
+
+      // 만료 대기
+      await new Promise((resolve) => setTimeout(resolve, 1100));
+
+      // When
+      const res = await request(app.getHttpServer())
+        .post('/api/v2/auth/logout')
+        .set('Cookie', `access_token=${expiredAccessToken}`)
+        .expect(401);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 401,
+        errorCode: 'JWT_EXPIRED',
+      });
+    });
+
+    it('로그아웃 후 같은 refresh token 으로 refresh 시도하면 401 JWT_INVALID 를 반환한다', async () => {
+      // Given
+      const { accessToken, refreshToken } = await loginTestUser();
+
+      // 로그아웃
+      await request(app.getHttpServer())
+        .post('/api/v2/auth/logout')
+        .set('Cookie', createAuthCookies(accessToken, refreshToken))
+        .expect(200);
+
+      // When — 로그아웃 후 refresh 시도
+      const res = await request(app.getHttpServer())
+        .post('/api/v2/auth/refresh')
+        .set('Cookie', `refresh_token=${refreshToken}`)
+        .expect(401);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 401,
+        errorCode: 'JWT_INVALID',
+      });
+    });
+  });
+});

--- a/test/code.e2e-spec.ts
+++ b/test/code.e2e-spec.ts
@@ -1,0 +1,658 @@
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { createTestApp, closeTestApp } from './helpers/setup';
+import { getAccessToken, createAuthHeaders } from './helpers/auth';
+import { seedTestUser, seedTestProblem, cleanDatabase } from './helpers/seed';
+import { PrismaService } from '../src/prisma/prisma.service';
+import { MAX_CODE_TEMPLATE_COUNT } from '../src/code/constants';
+
+describe('Code E2E', () => {
+  let app: INestApplication;
+  let prisma: PrismaService;
+
+  beforeAll(async () => {
+    const { app: testApp } = await createTestApp();
+    app = testApp;
+    prisma = app.get(PrismaService);
+  });
+
+  afterAll(async () => {
+    await cleanDatabase(prisma);
+    await closeTestApp(app);
+  });
+
+  afterEach(async () => {
+    await cleanDatabase(prisma);
+  });
+
+  // ─── 헬퍼 ──────────────────────────────────────────────────
+
+  async function createUserAndToken(overrides?: { uuid?: string }) {
+    const user = await seedTestUser(prisma, overrides);
+    const token = await getAccessToken(app, {
+      sub: user.uuid,
+      roles: [],
+    });
+    return { user, token, headers: createAuthHeaders(token) };
+  }
+
+  // ─── 코드 설정 (Setting) ────────────────────────────────────
+
+  describe('코드 설정 (Setting)', () => {
+    describe('GET /api/v1/code/setting', () => {
+      it('설정이 있는 유저 -- 200과 설정을 반환한다', async () => {
+        // Given
+        const { user, headers } = await createUserAndToken();
+        await prisma.codeSetting.create({
+          data: {
+            userUuid: user.uuid,
+            fontSize: 16,
+            problemContentRate: 150,
+            theme: 'vs-dark',
+            tabSize: 4,
+            lineNumber: 'on',
+            defaultLanguage: 'Python',
+          },
+        });
+
+        // When
+        const res = await request(app.getHttpServer())
+          .get('/api/v1/code/setting')
+          .set(headers)
+          .expect(200);
+
+        // Then
+        expect(res.body).toMatchObject({
+          statusCode: 200,
+          errorCode: '0000',
+          errorMessage: '',
+        });
+        expect(res.body.data).toMatchObject({
+          fontSize: 16,
+          problemContentRate: 150,
+          theme: 'vs-dark',
+          tabSize: 4,
+          lineNumber: 'on',
+          defaultLanguage: 'Python',
+        });
+      });
+
+      it('설정이 없는 유저 -- 404 CODE_SETTING_NOT_FOUND', async () => {
+        // Given
+        const { headers } = await createUserAndToken();
+
+        // When
+        const res = await request(app.getHttpServer())
+          .get('/api/v1/code/setting')
+          .set(headers)
+          .expect(404);
+
+        // Then
+        expect(res.body).toMatchObject({
+          statusCode: 404,
+          errorCode: 'CODE_SETTING_NOT_FOUND',
+        });
+      });
+    });
+
+    describe('PUT /api/v1/code/setting', () => {
+      it('최초 생성 -- 200', async () => {
+        // Given
+        const { headers } = await createUserAndToken();
+
+        // When
+        const res = await request(app.getHttpServer())
+          .put('/api/v1/code/setting')
+          .set(headers)
+          .send({
+            fontSize: 18,
+            problemContentRate: 120,
+            theme: 'light',
+            tabSize: 2,
+            lineNumber: 'relative',
+            defaultLanguage: 'Java',
+          })
+          .expect(200);
+
+        // Then
+        expect(res.body).toMatchObject({
+          statusCode: 200,
+          errorCode: '0000',
+          errorMessage: '',
+        });
+      });
+
+      it('기존 설정 업데이트 -- 200', async () => {
+        // Given
+        const { user, headers } = await createUserAndToken();
+        await prisma.codeSetting.create({
+          data: {
+            userUuid: user.uuid,
+            fontSize: 14,
+            problemContentRate: 100,
+            theme: 'vs-dark',
+            tabSize: 4,
+            lineNumber: 'on',
+            defaultLanguage: 'Python',
+          },
+        });
+
+        // When
+        const res = await request(app.getHttpServer())
+          .put('/api/v1/code/setting')
+          .set(headers)
+          .send({
+            fontSize: 20,
+            theme: 'light',
+          })
+          .expect(200);
+
+        // Then
+        expect(res.body).toMatchObject({
+          statusCode: 200,
+          errorCode: '0000',
+        });
+      });
+    });
+
+    it('토큰 없이 요청 -- 401', async () => {
+      // When
+      const res = await request(app.getHttpServer())
+        .get('/api/v1/code/setting')
+        .expect(401);
+
+      // Then
+      expect(res.body.statusCode).toBe(401);
+    });
+  });
+
+  // ─── 코드 템플릿 (Template CRUD) ─────────────────────────────
+
+  describe('코드 템플릿 (Template CRUD)', () => {
+    describe('GET /api/v1/code/template', () => {
+      it('템플릿이 있는 유저 -- 200과 목록을 반환한다', async () => {
+        // Given
+        const { user, headers } = await createUserAndToken();
+        await prisma.codeTemplate.create({
+          data: {
+            userUuid: user.uuid,
+            name: '템플릿 1',
+            language: 'Python',
+            content: 'print("hello")',
+            description: '테스트 템플릿',
+          },
+        });
+
+        // When
+        const res = await request(app.getHttpServer())
+          .get('/api/v1/code/template')
+          .set(headers)
+          .expect(200);
+
+        // Then
+        expect(res.body).toMatchObject({
+          statusCode: 200,
+          errorCode: '0000',
+          errorMessage: '',
+        });
+        expect(res.body.data.summaryList).toBeInstanceOf(Array);
+        expect(res.body.data.summaryList.length).toBe(1);
+        expect(res.body.data.defaultList).toBeInstanceOf(Array);
+      });
+
+      it('템플릿이 없는 유저 -- 200과 빈 목록을 반환한다', async () => {
+        // Given
+        const { headers } = await createUserAndToken();
+
+        // When
+        const res = await request(app.getHttpServer())
+          .get('/api/v1/code/template')
+          .set(headers)
+          .expect(200);
+
+        // Then
+        expect(res.body).toMatchObject({
+          statusCode: 200,
+          errorCode: '0000',
+        });
+        expect(res.body.data.summaryList).toEqual([]);
+        expect(res.body.data.defaultList).toEqual([]);
+      });
+    });
+
+    describe('GET /api/v1/code/template/:uuid', () => {
+      it('내 템플릿 -- 200과 템플릿 상세를 반환한다', async () => {
+        // Given
+        const { user, headers } = await createUserAndToken();
+        const template = await prisma.codeTemplate.create({
+          data: {
+            userUuid: user.uuid,
+            name: '상세 조회 템플릿',
+            language: 'Java',
+            content: 'public class Main {}',
+            description: '자바 템플릿',
+          },
+        });
+
+        // When
+        const res = await request(app.getHttpServer())
+          .get(`/api/v1/code/template/${template.uuid}`)
+          .set(headers)
+          .expect(200);
+
+        // Then
+        expect(res.body).toMatchObject({
+          statusCode: 200,
+          errorCode: '0000',
+        });
+        expect(res.body.data).toMatchObject({
+          uuid: template.uuid,
+          name: '상세 조회 템플릿',
+          language: 'Java',
+          content: 'public class Main {}',
+          description: '자바 템플릿',
+        });
+      });
+
+      it('존재하지 않는 UUID -- 404 CODE_TEMPLATE_NOT_FOUND', async () => {
+        // Given
+        const { headers } = await createUserAndToken();
+        const nonExistentUuid = '00000000-0000-0000-0000-000000000000';
+
+        // When
+        const res = await request(app.getHttpServer())
+          .get(`/api/v1/code/template/${nonExistentUuid}`)
+          .set(headers)
+          .expect(404);
+
+        // Then
+        expect(res.body).toMatchObject({
+          statusCode: 404,
+          errorCode: 'CODE_TEMPLATE_NOT_FOUND',
+        });
+      });
+
+      it('다른 유저의 템플릿 -- 404 CODE_TEMPLATE_NOT_FOUND', async () => {
+        // Given
+        const { headers } = await createUserAndToken();
+        const otherUser = await seedTestUser(prisma);
+        const otherTemplate = await prisma.codeTemplate.create({
+          data: {
+            userUuid: otherUser.uuid,
+            name: '다른 유저 템플릿',
+            language: 'Python',
+            content: 'print("other")',
+            description: '',
+          },
+        });
+
+        // When
+        const res = await request(app.getHttpServer())
+          .get(`/api/v1/code/template/${otherTemplate.uuid}`)
+          .set(headers)
+          .expect(404);
+
+        // Then
+        expect(res.body).toMatchObject({
+          statusCode: 404,
+          errorCode: 'CODE_TEMPLATE_NOT_FOUND',
+        });
+      });
+    });
+
+    describe('POST /api/v1/code/template', () => {
+      it('isDefault=false -- 200과 생성된 템플릿을 반환한다', async () => {
+        // Given
+        const { headers } = await createUserAndToken();
+
+        // When
+        const res = await request(app.getHttpServer())
+          .post('/api/v1/code/template')
+          .set(headers)
+          .send({
+            name: '새 템플릿',
+            content: 'console.log("hello")',
+            description: '노드 템플릿',
+            language: 'Node.js',
+            isDefault: false,
+          })
+          .expect(200);
+
+        // Then
+        expect(res.body).toMatchObject({
+          statusCode: 200,
+          errorCode: '0000',
+        });
+        expect(res.body.data).toMatchObject({
+          name: '새 템플릿',
+          content: 'console.log("hello")',
+          language: 'Node.js',
+        });
+        expect(res.body.data.uuid).toBeDefined();
+      });
+
+      it('isDefault=true -- 200과 기본 템플릿 설정', async () => {
+        // Given
+        const { user, headers } = await createUserAndToken();
+
+        // When
+        const res = await request(app.getHttpServer())
+          .post('/api/v1/code/template')
+          .set(headers)
+          .send({
+            name: '기본 템플릿',
+            content: 'print("default")',
+            description: '기본 파이썬 템플릿',
+            language: 'Python',
+            isDefault: true,
+          })
+          .expect(200);
+
+        // Then
+        expect(res.body).toMatchObject({
+          statusCode: 200,
+          errorCode: '0000',
+        });
+
+        // 기본 템플릿이 설정되었는지 확인
+        const defaultTemplate = await prisma.codeDefaultTemplate.findUnique({
+          where: {
+            userUuid_language: {
+              userUuid: user.uuid,
+              language: 'Python',
+            },
+          },
+        });
+        expect(defaultTemplate).not.toBeNull();
+      });
+
+      it('10개 보유 시 -- 409 CODE_TEMPLATE_LIMIT_EXCEEDED', async () => {
+        // Given
+        const { user, headers } = await createUserAndToken();
+        for (let i = 0; i < MAX_CODE_TEMPLATE_COUNT; i++) {
+          await prisma.codeTemplate.create({
+            data: {
+              userUuid: user.uuid,
+              name: `템플릿 ${i}`,
+              language: 'Python',
+              content: `print(${i})`,
+              description: '',
+            },
+          });
+        }
+
+        // When
+        const res = await request(app.getHttpServer())
+          .post('/api/v1/code/template')
+          .set(headers)
+          .send({
+            name: '11번째 템플릿',
+            content: 'print("over limit")',
+            language: 'Python',
+            isDefault: false,
+          })
+          .expect(409);
+
+        // Then
+        expect(res.body).toMatchObject({
+          statusCode: 409,
+          errorCode: 'CODE_TEMPLATE_LIMIT_EXCEEDED',
+        });
+      });
+    });
+
+    describe('PATCH /api/v1/code/template', () => {
+      it('존재하는 템플릿 수정 -- 200', async () => {
+        // Given
+        const { user, headers } = await createUserAndToken();
+        const template = await prisma.codeTemplate.create({
+          data: {
+            userUuid: user.uuid,
+            name: '수정 전 이름',
+            language: 'Python',
+            content: 'print("before")',
+            description: '수정 전',
+          },
+        });
+
+        // When
+        const res = await request(app.getHttpServer())
+          .patch('/api/v1/code/template')
+          .set(headers)
+          .send({
+            uuid: template.uuid,
+            name: '수정 후 이름',
+            content: 'print("after")',
+            description: '수정 후',
+            language: 'Python',
+            isDefault: false,
+          })
+          .expect(200);
+
+        // Then
+        expect(res.body).toMatchObject({
+          statusCode: 200,
+          errorCode: '0000',
+        });
+        expect(res.body.data).toMatchObject({
+          name: '수정 후 이름',
+          content: 'print("after")',
+        });
+      });
+
+      it('없는 UUID -- 404 CODE_TEMPLATE_NOT_FOUND', async () => {
+        // Given
+        const { headers } = await createUserAndToken();
+
+        // When
+        const res = await request(app.getHttpServer())
+          .patch('/api/v1/code/template')
+          .set(headers)
+          .send({
+            uuid: '00000000-0000-0000-0000-000000000000',
+            language: 'Python',
+            isDefault: false,
+          })
+          .expect(404);
+
+        // Then
+        expect(res.body).toMatchObject({
+          statusCode: 404,
+          errorCode: 'CODE_TEMPLATE_NOT_FOUND',
+        });
+      });
+    });
+
+    describe('DELETE /api/v1/code/template/:uuid', () => {
+      it('내 템플릿 삭제 -- 200', async () => {
+        // Given
+        const { user, headers } = await createUserAndToken();
+        const template = await prisma.codeTemplate.create({
+          data: {
+            userUuid: user.uuid,
+            name: '삭제할 템플릿',
+            language: 'C++',
+            content: '#include <iostream>',
+            description: '',
+          },
+        });
+
+        // When
+        const res = await request(app.getHttpServer())
+          .delete(`/api/v1/code/template/${template.uuid}`)
+          .set(headers)
+          .expect(200);
+
+        // Then
+        expect(res.body).toMatchObject({
+          statusCode: 200,
+          errorCode: '0000',
+        });
+      });
+
+      it('없는 UUID -- 404 CODE_TEMPLATE_NOT_FOUND', async () => {
+        // Given
+        const { headers } = await createUserAndToken();
+
+        // When
+        const res = await request(app.getHttpServer())
+          .delete('/api/v1/code/template/00000000-0000-0000-0000-000000000000')
+          .set(headers)
+          .expect(404);
+
+        // Then
+        expect(res.body).toMatchObject({
+          statusCode: 404,
+          errorCode: 'CODE_TEMPLATE_NOT_FOUND',
+        });
+      });
+
+      it('삭제 후 GET 조회 -- 404', async () => {
+        // Given
+        const { user, headers } = await createUserAndToken();
+        const template = await prisma.codeTemplate.create({
+          data: {
+            userUuid: user.uuid,
+            name: '삭제 후 조회 템플릿',
+            language: 'Java',
+            content: 'class Main {}',
+            description: '',
+          },
+        });
+
+        // 삭제
+        await request(app.getHttpServer())
+          .delete(`/api/v1/code/template/${template.uuid}`)
+          .set(headers)
+          .expect(200);
+
+        // When
+        const res = await request(app.getHttpServer())
+          .get(`/api/v1/code/template/${template.uuid}`)
+          .set(headers)
+          .expect(404);
+
+        // Then
+        expect(res.body).toMatchObject({
+          statusCode: 404,
+          errorCode: 'CODE_TEMPLATE_NOT_FOUND',
+        });
+      });
+    });
+  });
+
+  // ─── 문제 코드 (Problem Code) ─────────────────────────────────
+
+  describe('문제 코드 (Problem Code)', () => {
+    describe('GET /api/v1/code/problem/:problemUuid', () => {
+      it('저장된 코드가 있음 -- 200과 코드 목록을 반환한다', async () => {
+        // Given
+        const { user, headers } = await createUserAndToken();
+        const problem = await seedTestProblem(prisma);
+        await prisma.problemCode.create({
+          data: {
+            userUuid: user.uuid,
+            problemUuid: problem.uuid,
+            language: 'Python',
+            content: 'print("solution")',
+          },
+        });
+
+        // When
+        const res = await request(app.getHttpServer())
+          .get(`/api/v1/code/problem/${problem.uuid}`)
+          .set(headers)
+          .expect(200);
+
+        // Then
+        expect(res.body).toMatchObject({
+          statusCode: 200,
+          errorCode: '0000',
+          errorMessage: '',
+        });
+        expect(res.body.data).toBeInstanceOf(Array);
+        expect(res.body.data.length).toBe(1);
+        expect(res.body.data[0]).toMatchObject({
+          language: 'Python',
+          content: 'print("solution")',
+        });
+      });
+
+      it('저장된 코드가 없음 -- 200과 빈 배열을 반환한다', async () => {
+        // Given
+        const { headers } = await createUserAndToken();
+        const problem = await seedTestProblem(prisma);
+
+        // When
+        const res = await request(app.getHttpServer())
+          .get(`/api/v1/code/problem/${problem.uuid}`)
+          .set(headers)
+          .expect(200);
+
+        // Then
+        expect(res.body).toMatchObject({
+          statusCode: 200,
+          errorCode: '0000',
+        });
+        expect(res.body.data).toBeInstanceOf(Array);
+        expect(res.body.data.length).toBe(0);
+      });
+    });
+
+    describe('PUT /api/v1/code/problem', () => {
+      it('새 코드 저장 -- 200', async () => {
+        // Given
+        const { headers } = await createUserAndToken();
+        const problem = await seedTestProblem(prisma);
+
+        // When
+        const res = await request(app.getHttpServer())
+          .put('/api/v1/code/problem')
+          .set(headers)
+          .send({
+            problemUuid: problem.uuid,
+            language: 'Python',
+            content: 'print("new code")',
+          })
+          .expect(200);
+
+        // Then
+        expect(res.body).toMatchObject({
+          statusCode: 200,
+          errorCode: '0000',
+        });
+      });
+
+      it('같은 문제+언어 업데이트 -- 200', async () => {
+        // Given
+        const { user, headers } = await createUserAndToken();
+        const problem = await seedTestProblem(prisma);
+        await prisma.problemCode.create({
+          data: {
+            userUuid: user.uuid,
+            problemUuid: problem.uuid,
+            language: 'Java',
+            content: 'class Main {}',
+          },
+        });
+
+        // When
+        const res = await request(app.getHttpServer())
+          .put('/api/v1/code/problem')
+          .set(headers)
+          .send({
+            problemUuid: problem.uuid,
+            language: 'Java',
+            content: 'class Main { public static void main(String[] args) {} }',
+          })
+          .expect(200);
+
+        // Then
+        expect(res.body).toMatchObject({
+          statusCode: 200,
+          errorCode: '0000',
+        });
+      });
+    });
+  });
+});

--- a/test/execute.e2e-spec.ts
+++ b/test/execute.e2e-spec.ts
@@ -1,0 +1,194 @@
+import { INestApplication } from '@nestjs/common';
+import { io, Socket } from 'socket.io-client';
+import { createTestApp, closeTestApp } from './helpers/setup';
+import { getAccessToken } from './helpers/auth';
+import { JwtService } from '../src/jwt/jwt.service';
+
+let actualPort: number;
+
+describe('Execute Gateway E2E', () => {
+  let app: INestApplication;
+  let socket: Socket;
+
+  beforeAll(async () => {
+    const { app: testApp } = await createTestApp();
+    app = testApp;
+
+    await app.listen(0);
+    const url = await app.getUrl();
+    actualPort = Number(new URL(url).port);
+  });
+
+  afterAll(async () => {
+    await closeTestApp(app);
+  });
+
+  afterEach(() => {
+    socket?.disconnect();
+  });
+
+  function createSocket(): Socket {
+    return io(`http://localhost:${actualPort}`, {
+      transports: ['websocket'],
+      autoConnect: false,
+    });
+  }
+
+  async function createValidToken(): Promise<string> {
+    return getAccessToken(app, { sub: 'test-user-uuid', roles: [] });
+  }
+
+  describe('연결 & 인증', () => {
+    it('유효한 토큰으로 auth 전송 시 code 0000 응답을 받는다', (done) => {
+      socket = createSocket();
+
+      socket.on('connect', async () => {
+        const token = await createValidToken();
+        socket.emit('auth', { token });
+      });
+
+      socket.on('auth', (data: { code: string; result: string }) => {
+        expect(data.code).toBe('0000');
+        done();
+      });
+
+      socket.connect();
+    });
+
+    it('5초 내 auth를 보내지 않으면 연결이 끊긴다', (done) => {
+      socket = createSocket();
+
+      socket.on('disconnect', () => {
+        done();
+      });
+
+      socket.connect();
+    }, 10000);
+
+    it('잘못된 토큰으로 auth 전송 시 에러 응답 후 연결이 끊긴다', (done) => {
+      socket = createSocket();
+      let authReceived = false;
+
+      socket.on('connect', () => {
+        socket.emit('auth', { token: 'invalid-token' });
+      });
+
+      socket.on('auth', (data: { code: string; message: string }) => {
+        authReceived = true;
+        expect(data.code).toBe('JWT_INVALID');
+        expect(data.message).toBe('토큰이 유효하지 않습니다.');
+      });
+
+      socket.on('disconnect', () => {
+        expect(authReceived).toBe(true);
+        done();
+      });
+
+      socket.connect();
+    });
+
+    it('만료된 토큰으로 auth 전송 시 에러 응답 후 연결이 끊긴다', (done) => {
+      socket = createSocket();
+      let authReceived = false;
+
+      socket.on('connect', async () => {
+        const jwtService = app.get(JwtService);
+        // 만료 시간을 -1초로 설정하여 이미 만료된 토큰 생성
+        const expiredToken = await jwtService.sign(
+          { sub: 'test-user-uuid', roles: [] },
+          -1,
+        );
+        socket.emit('auth', { token: expiredToken });
+      });
+
+      socket.on('auth', (data: { code: string; message: string }) => {
+        authReceived = true;
+        expect(data.code).toBe('JWT_EXPIRED');
+        expect(data.message).toBe('토큰이 만료되었습니다.');
+      });
+
+      socket.on('disconnect', () => {
+        expect(authReceived).toBe(true);
+        done();
+      });
+
+      socket.connect();
+    });
+  });
+
+  describe('코드 실행', () => {
+    it('인증 없이 execute 전송 시 에러 응답을 받는다', (done) => {
+      socket = createSocket();
+
+      socket.on('connect', () => {
+        socket.emit('execute', {
+          provider: 'Python',
+          input: 'print("hello")',
+        });
+      });
+
+      // WsAuthGuard가 실패하면 ExecuteWsExceptionFilter를 통해 error 이벤트 발생
+      socket.on('error', (data: { code: string; result: string }) => {
+        expect(data).toBeDefined();
+        done();
+      });
+
+      // 인증 없이 execute 시 연결이 끊길 수도 있음 (타임아웃 포함)
+      // 에러 또는 연결 끊김 중 먼저 발생하는 것으로 테스트 종료
+      const timeout = setTimeout(() => {
+        // 5초 타임아웃으로 인해 연결 끊김이 발생할 수 있음
+        done();
+      }, 6000);
+
+      socket.on('disconnect', () => {
+        clearTimeout(timeout);
+        done();
+      });
+
+      socket.connect();
+    }, 10000);
+
+    // NOTE: 전체 코드 실행 테스트는 BullMQ 워커가 실행 중이어야 합니다.
+    // Redis와 BullMQ 워커가 없는 환경에서는 실행 결과를 받을 수 없으므로,
+    // execute 제출(submission) 자체의 동작만 검증합니다.
+    it('인증 후 execute 전송 시 요청이 수락된다', (done) => {
+      socket = createSocket();
+
+      socket.on('connect', async () => {
+        const token = await createValidToken();
+        socket.emit('auth', { token });
+      });
+
+      socket.on('auth', (data: { code: string }) => {
+        if (data.code !== '0000') {
+          done.fail('인증 실패');
+          return;
+        }
+
+        // 인증 성공 후 execute 전송
+        // BullMQ 워커가 없으면 타임아웃 또는 에러가 발생하지만,
+        // 요청 자체가 거부되지 않는 것을 확인
+        socket.emit(
+          'execute',
+          {
+            provider: 'Python',
+            input: 'print("hello")',
+          },
+          (response: Record<string, unknown>) => {
+            // ack 콜백이 호출되면 요청이 처리된 것
+            // BullMQ 연결 실패 시 에러 코드 반환
+            expect(response).toBeDefined();
+            done();
+          },
+        );
+
+        // BullMQ가 없는 경우 에러 응답을 받을 수 있음
+        setTimeout(() => {
+          done();
+        }, 5000);
+      });
+
+      socket.connect();
+    }, 15000);
+  });
+});

--- a/test/helpers/auth.ts
+++ b/test/helpers/auth.ts
@@ -26,9 +26,9 @@ export function createAuthCookies(
   accessToken: string,
   refreshToken?: string,
 ): string {
-  const cookies = [`accessToken=${accessToken}`];
+  const cookies = [`access_token=${accessToken}`];
   if (refreshToken) {
-    cookies.push(`refreshToken=${refreshToken}`);
+    cookies.push(`refresh_token=${refreshToken}`);
   }
   return cookies.join('; ');
 }

--- a/test/helpers/auth.ts
+++ b/test/helpers/auth.ts
@@ -1,0 +1,34 @@
+import { INestApplication } from '@nestjs/common';
+import { JwtService } from '../../src/jwt/jwt.service';
+import { Role } from '../../src/common/types/roles.type';
+
+export async function getAccessToken(
+  app: INestApplication,
+  { sub, roles }: { sub: string; roles: Role[] },
+): Promise<string> {
+  const jwtService = app.get(JwtService);
+  return jwtService.sign({ sub, roles });
+}
+
+export async function getRefreshToken(
+  app: INestApplication,
+  { sub }: { sub: string },
+): Promise<string> {
+  const jwtService = app.get(JwtService);
+  return jwtService.sign({ sub });
+}
+
+export function createAuthHeaders(token: string): { Authorization: string } {
+  return { Authorization: `Bearer ${token}` };
+}
+
+export function createAuthCookies(
+  accessToken: string,
+  refreshToken?: string,
+): string {
+  const cookies = [`accessToken=${accessToken}`];
+  if (refreshToken) {
+    cookies.push(`refreshToken=${refreshToken}`);
+  }
+  return cookies.join('; ');
+}

--- a/test/helpers/index.ts
+++ b/test/helpers/index.ts
@@ -1,0 +1,13 @@
+export { createTestApp, closeTestApp } from './setup';
+export {
+  getAccessToken,
+  getRefreshToken,
+  createAuthHeaders,
+  createAuthCookies,
+} from './auth';
+export {
+  seedTestUser,
+  seedTestUserWithRoles,
+  seedTestProblem,
+  cleanDatabase,
+} from './seed';

--- a/test/helpers/seed.ts
+++ b/test/helpers/seed.ts
@@ -1,0 +1,100 @@
+import { PrismaService } from '../../src/prisma/prisma.service';
+import { uuidv7 } from 'uuidv7';
+
+export async function seedTestUser(
+  prisma: PrismaService,
+  overrides?: Partial<{
+    uuid: string;
+    email: string;
+    name: string;
+    state: string;
+  }>,
+) {
+  const uuid = overrides?.uuid ?? uuidv7();
+  return prisma.user.create({
+    data: {
+      uuid,
+      email: overrides?.email ?? `test-${uuid}@test.com`,
+      name: overrides?.name ?? 'test-user',
+      profilePhoto: '',
+      emailVerified: false,
+      state: overrides?.state ?? 'ACTIVE',
+      lastLoginDate: new Date(),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+  });
+}
+
+export async function seedTestUserWithRoles(
+  prisma: PrismaService,
+  roles: string[],
+) {
+  const user = await seedTestUser(prisma);
+  for (const role of roles) {
+    await prisma.userRole.create({
+      data: {
+        userUuid: user.uuid,
+        role,
+      },
+    });
+  }
+  return user;
+}
+
+export async function seedTestProblem(
+  prisma: PrismaService,
+  overrides?: Partial<{
+    uuid: string;
+    title: string;
+    source: string;
+    sourceId: string;
+  }>,
+) {
+  const uuid = overrides?.uuid ?? uuidv7();
+  return prisma.problemV2.create({
+    data: {
+      uuid,
+      title: overrides?.title ?? 'test-problem',
+      level: 1,
+      levelText: 'Bronze V',
+      answerRate: 50.0,
+      submitCount: 100,
+      timeout: 1000,
+      memoryLimit: 256,
+      answerCount: 50,
+      answerPeopleCount: 50,
+      source: overrides?.source ?? 'baekjoon',
+      sourceUrl: 'https://www.acmicpc.net/problem/1000',
+      sourceId: overrides?.sourceId ?? `test-${uuid}`,
+      content: '<p>test problem content</p>',
+    },
+  });
+}
+
+const TABLE_NAMES = [
+  'USER_LOGIN_HISTORY',
+  'USER_SESSION',
+  'USER_ROLE',
+  'USER_OAUTH',
+  'USER_SOCIAL',
+  'PROBLEM_CODE',
+  'USER_PROBLEM_STATE',
+  'TODAY_PROBLEM',
+  'PROBLEM_V2_INPUT_OUTPUT',
+  'PROBLEM_V2_TYPE',
+  'PROBLEM_V2_SUB_TASK',
+  'PROBLEM_V2_LANGUAGE_LIMIT',
+  'PROBLEM_V2',
+  'CODE_DEFAULT_TEMPLATE',
+  'CODE_TEMPLATE',
+  'CODE_SETTING',
+  'PROBLEM_SITE_ACCOUNT',
+  'USER',
+] as const;
+
+export async function cleanDatabase(prisma: PrismaService): Promise<void> {
+  for (const table of TABLE_NAMES) {
+    await prisma.$executeRawUnsafe(`DELETE FROM \`${table}\``);
+  }
+}

--- a/test/helpers/setup.ts
+++ b/test/helpers/setup.ts
@@ -1,0 +1,32 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import * as cookieParser from 'cookie-parser';
+import { AppModule } from '../../src/app.module';
+
+export async function createTestApp(): Promise<{
+  app: INestApplication;
+  module: TestingModule;
+}> {
+  const module = await Test.createTestingModule({
+    imports: [AppModule],
+  }).compile();
+
+  const app = module.createNestApplication();
+
+  app.use(cookieParser());
+  app.useGlobalPipes(
+    new ValidationPipe({
+      transform: true,
+      whitelist: true,
+      transformOptions: { enableImplicitConversion: true },
+    }),
+  );
+
+  await app.init();
+
+  return { app, module };
+}
+
+export async function closeTestApp(app: INestApplication): Promise<void> {
+  await app.close();
+}

--- a/test/helpers/setup.ts
+++ b/test/helpers/setup.ts
@@ -1,15 +1,28 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { CanActivate, INestApplication, ValidationPipe } from '@nestjs/common';
 import * as cookieParser from 'cookie-parser';
 import { AppModule } from '../../src/app.module';
 
-export async function createTestApp(): Promise<{
+export async function createTestApp(options?: {
+  overrideGuards?: Array<{
+    guard: new (...args: never[]) => CanActivate;
+    mockValue: CanActivate;
+  }>;
+}): Promise<{
   app: INestApplication;
   module: TestingModule;
 }> {
-  const module = await Test.createTestingModule({
+  let builder = Test.createTestingModule({
     imports: [AppModule],
-  }).compile();
+  });
+
+  if (options?.overrideGuards) {
+    for (const { guard, mockValue } of options.overrideGuards) {
+      builder = builder.overrideGuard(guard).useValue(mockValue);
+    }
+  }
+
+  const module = await builder.compile();
 
   const app = module.createNestApplication();
 

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -1,16 +1,11 @@
 {
   "moduleFileExtensions": ["js", "json", "ts"],
-  "rootDir": ".",
+  "rootDir": "..",
   "testRegex": ".e2e-spec.ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
   },
-  "collectCoverageFrom": [
-    "**/*.(t|j)s"
-  ],
-  "coverageDirectory": "./coverage",
   "testEnvironment": "node",
-  "moduleNameMapper": {
-    "^@libs/(.*)$": "<rootDir>/libs/$1"
-  }
+  "testTimeout": 30000,
+  "roots": ["<rootDir>/test"]
 }

--- a/test/me.e2e-spec.ts
+++ b/test/me.e2e-spec.ts
@@ -1,0 +1,201 @@
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { createTestApp, closeTestApp } from './helpers/setup';
+import { getAccessToken, createAuthHeaders } from './helpers/auth';
+import { seedTestUser, cleanDatabase } from './helpers/seed';
+import { PrismaService } from '../src/prisma/prisma.service';
+import { JwtService } from '../src/jwt/jwt.service';
+
+describe('Me E2E', () => {
+  let app: INestApplication;
+  let prisma: PrismaService;
+
+  beforeAll(async () => {
+    const { app: testApp } = await createTestApp();
+    app = testApp;
+    prisma = app.get(PrismaService);
+  });
+
+  afterAll(async () => {
+    await closeTestApp(app);
+  });
+
+  afterEach(async () => {
+    await cleanDatabase(prisma);
+  });
+
+  describe('GET /api/v1/me', () => {
+    it('유효한 토큰과 정상 유저로 200과 내 정보를 반환한다', async () => {
+      // Given
+      const user = await seedTestUser(prisma, {
+        name: 'test-user',
+        email: 'me@test.com',
+      });
+      const accessToken = await getAccessToken(app, {
+        sub: user.uuid,
+        roles: [],
+      });
+
+      // When
+      const res = await request(app.getHttpServer())
+        .get('/api/v1/me')
+        .set(createAuthHeaders(accessToken))
+        .expect(200);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 200,
+        errorCode: '0000',
+        errorMessage: '',
+      });
+      expect(res.body.data).toMatchObject({
+        uuid: user.uuid,
+        name: 'test-user',
+        email: 'me@test.com',
+        profilePhoto: '',
+      });
+      expect(Array.isArray(res.body.data.socialList)).toBe(true);
+      expect(Array.isArray(res.body.data.oauthList)).toBe(true);
+    });
+
+    it('토큰이 없으면 401 JWT_MISSING 을 반환한다', async () => {
+      // When
+      const res = await request(app.getHttpServer())
+        .get('/api/v1/me')
+        .expect(401);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 401,
+        errorCode: 'JWT_MISSING',
+      });
+    });
+
+    it('만료된 토큰이면 401 JWT_EXPIRED 를 반환한다', async () => {
+      // Given
+      const user = await seedTestUser(prisma);
+      const jwtService = app.get(JwtService);
+      const expiredToken = await jwtService.sign(
+        { sub: user.uuid, roles: [] },
+        0,
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 1100));
+
+      // When
+      const res = await request(app.getHttpServer())
+        .get('/api/v1/me')
+        .set(createAuthHeaders(expiredToken))
+        .expect(401);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 401,
+        errorCode: 'JWT_EXPIRED',
+      });
+    });
+
+    it('DB에 없는 UUID 토큰이면 404 USER_NOT_FOUND 를 반환한다', async () => {
+      // Given
+      const nonExistentUuid = '00000000-0000-0000-0000-000000000000';
+      const accessToken = await getAccessToken(app, {
+        sub: nonExistentUuid,
+        roles: [],
+      });
+
+      // When
+      const res = await request(app.getHttpServer())
+        .get('/api/v1/me')
+        .set(createAuthHeaders(accessToken))
+        .expect(404);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 404,
+        errorCode: 'USER_NOT_FOUND',
+      });
+    });
+
+    it('socialList 와 oauthList 가 비어있는 유저는 빈 배열을 반환한다', async () => {
+      // Given
+      const user = await seedTestUser(prisma);
+      const accessToken = await getAccessToken(app, {
+        sub: user.uuid,
+        roles: [],
+      });
+
+      // When
+      const res = await request(app.getHttpServer())
+        .get('/api/v1/me')
+        .set(createAuthHeaders(accessToken))
+        .expect(200);
+
+      // Then
+      expect(res.body.data.socialList).toEqual([]);
+      expect(res.body.data.oauthList).toEqual([]);
+    });
+  });
+
+  describe('PATCH /api/v1/me/profile', () => {
+    it('이름만 변경하면 200과 업데이트된 정보를 반환한다', async () => {
+      // Given
+      const user = await seedTestUser(prisma, { name: 'old-name' });
+      const accessToken = await getAccessToken(app, {
+        sub: user.uuid,
+        roles: [],
+      });
+
+      // When
+      const res = await request(app.getHttpServer())
+        .patch('/api/v1/me/profile')
+        .set(createAuthHeaders(accessToken))
+        .field('name', 'new-name')
+        .expect(200);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 200,
+        errorCode: '0000',
+        errorMessage: '',
+      });
+      expect(res.body.data.name).toBe('new-name');
+      expect(res.body.data.uuid).toBe(user.uuid);
+    });
+
+    it('body 가 비어있으면 200과 기존 정보를 반환한다', async () => {
+      // Given
+      const user = await seedTestUser(prisma, { name: 'keep-name' });
+      const accessToken = await getAccessToken(app, {
+        sub: user.uuid,
+        roles: [],
+      });
+
+      // When
+      const res = await request(app.getHttpServer())
+        .patch('/api/v1/me/profile')
+        .set(createAuthHeaders(accessToken))
+        .expect(200);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 200,
+        errorCode: '0000',
+        errorMessage: '',
+      });
+      expect(res.body.data.name).toBe('keep-name');
+    });
+
+    it('토큰이 없으면 401 JWT_MISSING 을 반환한다', async () => {
+      // When
+      const res = await request(app.getHttpServer())
+        .patch('/api/v1/me/profile')
+        .expect(401);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 401,
+        errorCode: 'JWT_MISSING',
+      });
+    });
+  });
+});

--- a/test/oauth.e2e-spec.ts
+++ b/test/oauth.e2e-spec.ts
@@ -1,0 +1,463 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  INestApplication,
+} from '@nestjs/common';
+import * as request from 'supertest';
+import { createTestApp, closeTestApp } from './helpers/setup';
+import { getAccessToken, createAuthHeaders } from './helpers/auth';
+import { seedTestUser, cleanDatabase } from './helpers/seed';
+import { PrismaService } from '../src/prisma/prisma.service';
+import { DynamicOAuthGuard } from '../src/oauth-v2/dynamic-oauth.guard';
+import { OAuthRequestUser } from '../src/common/types/oauth.type';
+import { OAUTH_PROVIDER } from '../src/common/constants/oauth.contant';
+
+let mockOAuthProfile: OAuthRequestUser;
+
+const MockDynamicOAuthGuard: CanActivate = {
+  canActivate(context: ExecutionContext): boolean {
+    const req = context.switchToHttp().getRequest();
+    req.oauth = mockOAuthProfile;
+    return true;
+  },
+};
+
+describe('OAuth E2E', () => {
+  let app: INestApplication;
+  let prisma: PrismaService;
+
+  beforeAll(async () => {
+    const { app: testApp } = await createTestApp({
+      overrideGuards: [
+        { guard: DynamicOAuthGuard, mockValue: MockDynamicOAuthGuard },
+      ],
+    });
+    app = testApp;
+    prisma = app.get(PrismaService);
+  });
+
+  afterAll(async () => {
+    await closeTestApp(app);
+  });
+
+  afterEach(async () => {
+    await cleanDatabase(prisma);
+  });
+
+  describe('POST /api/v2/oauth/:provider (로그인/회원가입)', () => {
+    const PROVIDER = OAUTH_PROVIDER.GOOGLE;
+    const BASE_PROFILE: OAuthRequestUser = {
+      provider: PROVIDER,
+      id: 'oauth-test-id-001',
+      name: '테스트유저',
+      email: 'oauth-test@test.com',
+      accessToken: 'mock-access-token',
+    };
+
+    beforeEach(() => {
+      mockOAuthProfile = { ...BASE_PROFILE };
+    });
+
+    it('신규 유저는 회원가입 후 토큰을 발급받는다', async () => {
+      // Given — DB에 해당 OAuth 레코드 없음 (NEW 상태)
+
+      // When
+      const res = await request(app.getHttpServer())
+        .post(`/api/v2/oauth/${PROVIDER}`)
+        .expect(201);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 201,
+        errorCode: '0000',
+        errorMessage: '',
+      });
+      expect(res.body.data).toHaveProperty('accessToken');
+      expect(res.body.data).toHaveProperty('refreshToken');
+      expect(typeof res.body.data.accessToken).toBe('string');
+      expect(typeof res.body.data.refreshToken).toBe('string');
+
+      // 쿠키에 토큰이 설정되었는지 확인
+      const cookies = res.headers['set-cookie'];
+      expect(cookies).toBeDefined();
+      const cookieStr = Array.isArray(cookies) ? cookies.join('; ') : cookies;
+      expect(cookieStr).toContain('access_token=');
+      expect(cookieStr).toContain('refresh_token=');
+    });
+
+    it('신규 가입 후 DB에 유저와 OAuth 레코드가 생성된다', async () => {
+      // Given — 신규 유저
+
+      // When
+      await request(app.getHttpServer())
+        .post(`/api/v2/oauth/${PROVIDER}`)
+        .expect(201);
+
+      // Then — DB에 UserOAuth 레코드가 존재
+      const oauthRecord = await prisma.userOAuth.findUnique({
+        where: {
+          id_provider: {
+            id: BASE_PROFILE.id,
+            provider: PROVIDER,
+          },
+        },
+      });
+      expect(oauthRecord).not.toBeNull();
+      expect(oauthRecord!.isActive).toBe(true);
+
+      // 유저도 생성되었는지 확인
+      const user = await prisma.user.findUnique({
+        where: { uuid: oauthRecord!.userUuid },
+      });
+      expect(user).not.toBeNull();
+      expect(user!.email).toBe(BASE_PROFILE.email);
+    });
+
+    it('기존 유저 활성 OAuth 상태이면 로그인 토큰을 반환한다', async () => {
+      // Given — CONNECTED_AND_ACTIVE 상태
+      const user = await seedTestUser(prisma);
+      await prisma.userOAuth.create({
+        data: {
+          userUuid: user.uuid,
+          id: BASE_PROFILE.id,
+          provider: PROVIDER,
+          isActive: true,
+        },
+      });
+
+      // When
+      const res = await request(app.getHttpServer())
+        .post(`/api/v2/oauth/${PROVIDER}`)
+        .expect(201);
+
+      // Then
+      expect(res.body.data).toHaveProperty('accessToken');
+      expect(res.body.data).toHaveProperty('refreshToken');
+    });
+
+    it('비활성 OAuth 상태이면 재활성화 후 로그인한다', async () => {
+      // Given — CONNECTED_AND_INACTIVE 상태
+      const user = await seedTestUser(prisma);
+      await prisma.userOAuth.create({
+        data: {
+          userUuid: user.uuid,
+          id: BASE_PROFILE.id,
+          provider: PROVIDER,
+          isActive: false,
+        },
+      });
+
+      // When
+      const res = await request(app.getHttpServer())
+        .post(`/api/v2/oauth/${PROVIDER}`)
+        .expect(201);
+
+      // Then
+      expect(res.body.data).toHaveProperty('accessToken');
+      expect(res.body.data).toHaveProperty('refreshToken');
+
+      // OAuth 레코드가 재활성화되었는지 확인
+      const oauthRecord = await prisma.userOAuth.findUnique({
+        where: {
+          id_provider: {
+            id: BASE_PROFILE.id,
+            provider: PROVIDER,
+          },
+        },
+      });
+      expect(oauthRecord!.isActive).toBe(true);
+    });
+
+    it('다른 계정에 활성 연결된 OAuth이면 해당 계정으로 로그인한다', async () => {
+      // Given — CONNECTED_TO_OTHER_ACCOUNT 상태
+      const otherUser = await seedTestUser(prisma, {
+        email: 'other@test.com',
+      });
+      await prisma.userOAuth.create({
+        data: {
+          userUuid: otherUser.uuid,
+          id: BASE_PROFILE.id,
+          provider: PROVIDER,
+          isActive: true,
+        },
+      });
+
+      // When
+      const res = await request(app.getHttpServer())
+        .post(`/api/v2/oauth/${PROVIDER}`)
+        .expect(201);
+
+      // Then
+      expect(res.body.data).toHaveProperty('accessToken');
+      expect(res.body.data).toHaveProperty('refreshToken');
+    });
+
+    it('다른 계정에 비활성 연결된 OAuth이면 재활성화 후 로그인한다', async () => {
+      // Given — DISCONNECTED_FROM_OTHER_ACCOUNT 상태
+      const otherUser = await seedTestUser(prisma, {
+        email: 'other2@test.com',
+      });
+      await prisma.userOAuth.create({
+        data: {
+          userUuid: otherUser.uuid,
+          id: BASE_PROFILE.id,
+          provider: PROVIDER,
+          isActive: false,
+        },
+      });
+
+      // When
+      const res = await request(app.getHttpServer())
+        .post(`/api/v2/oauth/${PROVIDER}`)
+        .expect(201);
+
+      // Then
+      expect(res.body.data).toHaveProperty('accessToken');
+      expect(res.body.data).toHaveProperty('refreshToken');
+
+      // 재활성화 확인
+      const oauthRecord = await prisma.userOAuth.findUnique({
+        where: {
+          id_provider: {
+            id: BASE_PROFILE.id,
+            provider: PROVIDER,
+          },
+        },
+      });
+      expect(oauthRecord!.isActive).toBe(true);
+    });
+  });
+
+  describe('POST /api/v2/oauth/connect/:provider (OAuth 연동)', () => {
+    const PROVIDER = OAUTH_PROVIDER.GOOGLE;
+    const CONNECT_PROFILE: OAuthRequestUser = {
+      provider: PROVIDER,
+      id: 'connect-test-id-001',
+      name: '연동테스트',
+      email: 'connect-test@test.com',
+      accessToken: 'mock-connect-token',
+    };
+
+    beforeEach(() => {
+      mockOAuthProfile = { ...CONNECT_PROFILE };
+    });
+
+    it('로그인 상태에서 새 OAuth를 연결한다', async () => {
+      // Given
+      const user = await seedTestUser(prisma);
+      const accessToken = await getAccessToken(app, {
+        sub: user.uuid,
+        roles: [],
+      });
+
+      // When
+      const res = await request(app.getHttpServer())
+        .post(`/api/v2/oauth/connect/${PROVIDER}`)
+        .set(createAuthHeaders(accessToken))
+        .expect(201);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 201,
+        errorCode: '0000',
+      });
+
+      // DB에 OAuth 레코드가 생성되었는지 확인
+      const oauthRecord = await prisma.userOAuth.findUnique({
+        where: {
+          id_provider: {
+            id: CONNECT_PROFILE.id,
+            provider: PROVIDER,
+          },
+        },
+      });
+      expect(oauthRecord).not.toBeNull();
+      expect(oauthRecord!.userUuid).toBe(user.uuid);
+      expect(oauthRecord!.isActive).toBe(true);
+    });
+
+    it('이미 내 계정에 활성 연결된 OAuth이면 멱등하게 처리한다', async () => {
+      // Given — CONNECTED_AND_ACTIVE 상태 (내 계정)
+      const user = await seedTestUser(prisma);
+      await prisma.userOAuth.create({
+        data: {
+          userUuid: user.uuid,
+          id: CONNECT_PROFILE.id,
+          provider: PROVIDER,
+          isActive: true,
+        },
+      });
+      const accessToken = await getAccessToken(app, {
+        sub: user.uuid,
+        roles: [],
+      });
+
+      // When
+      const res = await request(app.getHttpServer())
+        .post(`/api/v2/oauth/connect/${PROVIDER}`)
+        .set(createAuthHeaders(accessToken))
+        .expect(201);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 201,
+        errorCode: '0000',
+      });
+    });
+
+    it('내 계정에 비활성 연결된 OAuth이면 재활성화한다', async () => {
+      // Given — CONNECTED_AND_INACTIVE 상태 (내 계정)
+      const user = await seedTestUser(prisma);
+      await prisma.userOAuth.create({
+        data: {
+          userUuid: user.uuid,
+          id: CONNECT_PROFILE.id,
+          provider: PROVIDER,
+          isActive: false,
+        },
+      });
+      const accessToken = await getAccessToken(app, {
+        sub: user.uuid,
+        roles: [],
+      });
+
+      // When
+      const res = await request(app.getHttpServer())
+        .post(`/api/v2/oauth/connect/${PROVIDER}`)
+        .set(createAuthHeaders(accessToken))
+        .expect(201);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 201,
+        errorCode: '0000',
+      });
+
+      // 재활성화 확인
+      const oauthRecord = await prisma.userOAuth.findUnique({
+        where: {
+          id_provider: {
+            id: CONNECT_PROFILE.id,
+            provider: PROVIDER,
+          },
+        },
+      });
+      expect(oauthRecord!.isActive).toBe(true);
+    });
+
+    it('다른 유저에 연결된 OAuth이면 409 OAUTH_CONFLICT를 반환한다', async () => {
+      // Given — CONNECTED_TO_OTHER_ACCOUNT 상태
+      const myUser = await seedTestUser(prisma, {
+        email: 'my-user@test.com',
+      });
+      const otherUser = await seedTestUser(prisma, {
+        email: 'other-user@test.com',
+      });
+      await prisma.userOAuth.create({
+        data: {
+          userUuid: otherUser.uuid,
+          id: CONNECT_PROFILE.id,
+          provider: PROVIDER,
+          isActive: true,
+        },
+      });
+      const accessToken = await getAccessToken(app, {
+        sub: myUser.uuid,
+        roles: [],
+      });
+
+      // When
+      const res = await request(app.getHttpServer())
+        .post(`/api/v2/oauth/connect/${PROVIDER}`)
+        .set(createAuthHeaders(accessToken))
+        .expect(409);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 409,
+        errorCode: 'OAUTH_CONFLICT',
+      });
+    });
+
+    it('비로그인 상태이면 401 JWT_MISSING을 반환한다', async () => {
+      // When — 토큰 없이 요청
+      const res = await request(app.getHttpServer())
+        .post(`/api/v2/oauth/connect/${PROVIDER}`)
+        .expect(401);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 401,
+        errorCode: 'JWT_MISSING',
+      });
+    });
+  });
+
+  describe('POST /api/v2/oauth/disconnect/:provider (OAuth 해제)', () => {
+    const PROVIDER = OAUTH_PROVIDER.GOOGLE;
+    const DISCONNECT_PROFILE: OAuthRequestUser = {
+      provider: PROVIDER,
+      id: 'disconnect-test-id-001',
+      name: '해제테스트',
+      email: 'disconnect-test@test.com',
+      accessToken: 'mock-disconnect-token',
+    };
+
+    beforeEach(() => {
+      mockOAuthProfile = { ...DISCONNECT_PROFILE };
+    });
+
+    it('내 계정에 연결된 OAuth를 해제한다', async () => {
+      // Given
+      const user = await seedTestUser(prisma);
+      await prisma.userOAuth.create({
+        data: {
+          userUuid: user.uuid,
+          id: DISCONNECT_PROFILE.id,
+          provider: PROVIDER,
+          isActive: true,
+        },
+      });
+      const accessToken = await getAccessToken(app, {
+        sub: user.uuid,
+        roles: [],
+      });
+
+      // When
+      const res = await request(app.getHttpServer())
+        .post(`/api/v2/oauth/disconnect/${PROVIDER}`)
+        .set(createAuthHeaders(accessToken))
+        .expect(201);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 201,
+        errorCode: '0000',
+      });
+
+      // OAuth 레코드가 비활성화되었는지 확인
+      const oauthRecord = await prisma.userOAuth.findUnique({
+        where: {
+          id_provider: {
+            id: DISCONNECT_PROFILE.id,
+            provider: PROVIDER,
+          },
+        },
+      });
+      expect(oauthRecord!.isActive).toBe(false);
+    });
+
+    it('비로그인 상태이면 401 JWT_MISSING을 반환한다', async () => {
+      // When — 토큰 없이 요청
+      const res = await request(app.getHttpServer())
+        .post(`/api/v2/oauth/disconnect/${PROVIDER}`)
+        .expect(401);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 401,
+        errorCode: 'JWT_MISSING',
+      });
+    });
+  });
+});

--- a/test/problem-site.e2e-spec.ts
+++ b/test/problem-site.e2e-spec.ts
@@ -1,0 +1,281 @@
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { createTestApp, closeTestApp } from './helpers/setup';
+import { getAccessToken, createAuthHeaders } from './helpers/auth';
+import {
+  seedTestUser,
+  seedTestUserWithRoles,
+  cleanDatabase,
+} from './helpers/seed';
+import { PrismaService } from '../src/prisma/prisma.service';
+
+describe('ProblemSite E2E', () => {
+  let app: INestApplication;
+  let prisma: PrismaService;
+
+  beforeAll(async () => {
+    const { app: testApp } = await createTestApp();
+    app = testApp;
+    prisma = app.get(PrismaService);
+  });
+
+  afterAll(async () => {
+    await cleanDatabase(prisma);
+    await closeTestApp(app);
+  });
+
+  afterEach(async () => {
+    await cleanDatabase(prisma);
+  });
+
+  // ─── 헬퍼 ──────────────────────────────────────────────────
+
+  async function createVipUserAndToken() {
+    const user = await seedTestUserWithRoles(prisma, ['VIP']);
+    const token = await getAccessToken(app, {
+      sub: user.uuid,
+      roles: ['VIP'],
+    });
+    return { user, token, headers: createAuthHeaders(token) };
+  }
+
+  async function createAdminUserAndToken() {
+    const user = await seedTestUserWithRoles(prisma, ['ADMIN']);
+    const token = await getAccessToken(app, {
+      sub: user.uuid,
+      roles: ['ADMIN'],
+    });
+    return { user, token, headers: createAuthHeaders(token) };
+  }
+
+  async function createRegularUserAndToken() {
+    const user = await seedTestUser(prisma);
+    const token = await getAccessToken(app, {
+      sub: user.uuid,
+      roles: [],
+    });
+    return { user, token, headers: createAuthHeaders(token) };
+  }
+
+  // ─── POST /api/v1/problem-site ────────────────────────────
+
+  describe('POST /api/v1/problem-site', () => {
+    it('VIP 유저가 유효한 provider/handle 로 요청하면 201을 반환한다', async () => {
+      // Given
+      const { headers } = await createVipUserAndToken();
+
+      // When
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/problem-site')
+        .set(headers)
+        .send({ provider: 'BOJ', handle: 'test_handle' })
+        .expect(201);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 201,
+        errorCode: '0000',
+        errorMessage: '',
+      });
+      expect(res.body.data).toMatchObject({
+        provider: 'BOJ',
+        handle: 'test_handle',
+      });
+      expect(res.body.data).toHaveProperty('userUuid');
+      expect(res.body.data).toHaveProperty('createdAt');
+    });
+
+    it('ADMIN 유저가 요청하면 201을 반환한다', async () => {
+      // Given
+      const { headers } = await createAdminUserAndToken();
+
+      // When
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/problem-site')
+        .set(headers)
+        .send({ provider: 'BOJ', handle: 'admin_handle' })
+        .expect(201);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 201,
+        errorCode: '0000',
+        errorMessage: '',
+      });
+      expect(res.body.data).toMatchObject({
+        provider: 'BOJ',
+        handle: 'admin_handle',
+      });
+    });
+
+    it('일반 유저(권한 없음)가 요청하면 403 FORBIDDEN을 반환한다', async () => {
+      // Given
+      const { headers } = await createRegularUserAndToken();
+
+      // When
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/problem-site')
+        .set(headers)
+        .send({ provider: 'BOJ', handle: 'regular_handle' })
+        .expect(403);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 403,
+        errorCode: 'FORBIDDEN',
+      });
+    });
+
+    it('비로그인 상태에서 요청하면 401 JWT_MISSING을 반환한다', async () => {
+      // When
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/problem-site')
+        .send({ provider: 'BOJ', handle: 'no_auth_handle' })
+        .expect(401);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 401,
+        errorCode: 'JWT_MISSING',
+      });
+    });
+
+    it('같은 provider로 중복 생성 시 에러를 반환한다', async () => {
+      // Given
+      const { user, headers } = await createVipUserAndToken();
+      await prisma.problemSiteAccount.create({
+        data: {
+          userUuid: user.uuid,
+          provider: 'BOJ',
+          handle: 'existing_handle',
+        },
+      });
+
+      // When
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/problem-site')
+        .set(headers)
+        .send({ provider: 'BOJ', handle: 'new_handle' });
+
+      // Then -- unique constraint (userUuid+provider) 위반
+      expect(res.body.statusCode).toBeGreaterThanOrEqual(400);
+    });
+
+    it('provider가 빈 값이면 400을 반환한다', async () => {
+      // Given
+      const { headers } = await createVipUserAndToken();
+
+      // When
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/problem-site')
+        .set(headers)
+        .send({ provider: '', handle: 'test_handle' })
+        .expect(400);
+
+      // Then
+      expect(res.body.statusCode).toBe(400);
+    });
+
+    it('handle이 빈 값이면 400을 반환한다', async () => {
+      // Given
+      const { headers } = await createVipUserAndToken();
+
+      // When
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/problem-site')
+        .set(headers)
+        .send({ provider: 'BOJ', handle: '' })
+        .expect(400);
+
+      // Then
+      expect(res.body.statusCode).toBe(400);
+    });
+
+    it('provider와 handle 모두 누락이면 400을 반환한다', async () => {
+      // Given
+      const { headers } = await createVipUserAndToken();
+
+      // When
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/problem-site')
+        .set(headers)
+        .send({})
+        .expect(400);
+
+      // Then
+      expect(res.body.statusCode).toBe(400);
+    });
+  });
+
+  // ─── DELETE /api/v1/problem-site/:provider ─────────────────
+
+  describe('DELETE /api/v1/problem-site/:provider', () => {
+    it('연동된 provider를 삭제하면 200을 반환한다', async () => {
+      // Given
+      const { user, headers } = await createVipUserAndToken();
+      await prisma.problemSiteAccount.create({
+        data: {
+          userUuid: user.uuid,
+          provider: 'BOJ',
+          handle: 'to_delete_handle',
+        },
+      });
+
+      // When
+      const res = await request(app.getHttpServer())
+        .delete('/api/v1/problem-site/BOJ')
+        .set(headers)
+        .expect(200);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 200,
+        errorCode: '0000',
+        errorMessage: '',
+      });
+    });
+
+    it('연동되지 않은 provider를 삭제하면 에러를 반환한다', async () => {
+      // Given
+      const { headers } = await createVipUserAndToken();
+
+      // When
+      const res = await request(app.getHttpServer())
+        .delete('/api/v1/problem-site/BOJ')
+        .set(headers);
+
+      // Then -- Prisma P2025: record not found
+      expect(res.body.statusCode).toBeGreaterThanOrEqual(400);
+    });
+
+    it('일반 유저가 삭제 요청하면 403 FORBIDDEN을 반환한다', async () => {
+      // Given
+      const { headers } = await createRegularUserAndToken();
+
+      // When
+      const res = await request(app.getHttpServer())
+        .delete('/api/v1/problem-site/BOJ')
+        .set(headers)
+        .expect(403);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 403,
+        errorCode: 'FORBIDDEN',
+      });
+    });
+
+    it('비로그인 상태에서 삭제 요청하면 401 JWT_MISSING을 반환한다', async () => {
+      // When
+      const res = await request(app.getHttpServer())
+        .delete('/api/v1/problem-site/BOJ')
+        .expect(401);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 401,
+        errorCode: 'JWT_MISSING',
+      });
+    });
+  });
+});

--- a/test/problems.e2e-spec.ts
+++ b/test/problems.e2e-spec.ts
@@ -1,0 +1,598 @@
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { createTestApp, closeTestApp } from './helpers/setup';
+import { getAccessToken, createAuthHeaders } from './helpers/auth';
+import { seedTestUser, cleanDatabase } from './helpers/seed';
+import { PrismaService } from '../src/prisma/prisma.service';
+import { uuidv7 } from 'uuidv7';
+
+describe('Problems V2 E2E', () => {
+  let app: INestApplication;
+  let prisma: PrismaService;
+
+  beforeAll(async () => {
+    const { app: testApp } = await createTestApp();
+    app = testApp;
+    prisma = app.get(PrismaService);
+  });
+
+  afterAll(async () => {
+    await closeTestApp(app);
+  });
+
+  afterEach(async () => {
+    await cleanDatabase(prisma);
+  });
+
+  // ─── 시드 헬퍼 ──────────────────────────────────────────────
+
+  async function seedProblemWithType(
+    overrides: Partial<{
+      uuid: string;
+      title: string;
+      level: number;
+      levelText: string;
+      answerRate: number;
+      submitCount: number;
+    }>,
+    typeNames: string[] = [],
+  ) {
+    const uuid = overrides.uuid ?? uuidv7();
+    const problem = await prisma.problemV2.create({
+      data: {
+        uuid,
+        title: overrides.title ?? 'test-problem',
+        level: overrides.level ?? 1,
+        levelText: overrides.levelText ?? 'Bronze V',
+        answerRate: overrides.answerRate ?? 50.0,
+        submitCount: overrides.submitCount ?? 100,
+        timeout: 1000,
+        memoryLimit: 256,
+        answerCount: 50,
+        answerPeopleCount: 50,
+        source: 'baekjoon',
+        sourceUrl: 'https://www.acmicpc.net/problem/1000',
+        sourceId: `test-${uuid}`,
+        content: '<p>test problem content</p>',
+      },
+    });
+
+    for (const name of typeNames) {
+      await prisma.problemV2Type.create({
+        data: {
+          name,
+          problemUuid: uuid,
+        },
+      });
+    }
+
+    return problem;
+  }
+
+  async function seedTodayProblem(problemUuid: string, servedAt: Date) {
+    return prisma.todayProblem.create({
+      data: {
+        problemUuid,
+        servedAt,
+      },
+    });
+  }
+
+  async function seedUserProblemState(
+    userUuid: string,
+    problemUuid: string,
+    state: string,
+  ) {
+    return prisma.userProblemState.create({
+      data: {
+        userUuid,
+        problemUuid,
+        state,
+      },
+    });
+  }
+
+  // ─── GET /api/v2/problems (목록) ─────────────────────────────
+
+  describe('GET /api/v2/problems', () => {
+    it('기본 조회 (파라미터 없음) — 200과 첫 페이지를 반환한다', async () => {
+      // Given
+      await seedProblemWithType({ title: '문제 A', level: 1 });
+      await seedProblemWithType({ title: '문제 B', level: 2 });
+
+      // When
+      const res = await request(app.getHttpServer())
+        .get('/api/v2/problems')
+        .expect(200);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 200,
+        errorCode: '0000',
+        errorMessage: '',
+      });
+      expect(res.body.data.problemList).toBeInstanceOf(Array);
+      expect(res.body.data.problemList.length).toBe(2);
+    });
+
+    it('pageNo=1, pageSize=10 — 200과 10개 이하를 반환한다', async () => {
+      // Given
+      for (let i = 0; i < 3; i++) {
+        await seedProblemWithType({ title: `문제 ${i}`, level: i + 1 });
+      }
+
+      // When
+      const res = await request(app.getHttpServer())
+        .get('/api/v2/problems')
+        .query({ pageNo: 1, pageSize: 10 })
+        .expect(200);
+
+      // Then
+      expect(res.body.data.problemList.length).toBeLessThanOrEqual(10);
+      expect(res.body.data.problemList.length).toBe(3);
+    });
+
+    it('pageSize 허용되지 않는 값 (15) — 400 validation error', async () => {
+      // When
+      const res = await request(app.getHttpServer())
+        .get('/api/v2/problems')
+        .query({ pageSize: 15 })
+        .expect(400);
+
+      // Then
+      expect(res.body.statusCode).toBe(400);
+      expect(res.body.errorMessage).toContain(
+        '10, 20 또는 50 단위로만 조회가 가능합니다.',
+      );
+    });
+
+    it('pageNo=-1 — 400 validation error', async () => {
+      // When
+      const res = await request(app.getHttpServer())
+        .get('/api/v2/problems')
+        .query({ pageNo: -1 })
+        .expect(400);
+
+      // Then
+      expect(res.body.statusCode).toBe(400);
+      expect(res.body.errorMessage).toContain(
+        '페이지 번호는 0페이지보다 커야 합니다.',
+      );
+    });
+
+    it('title 검색 — 2자 이상 일반 문자열로 검색하면 200과 결과를 반환한다', async () => {
+      // Given
+      await seedProblemWithType({ title: '피보나치 수열', level: 5 });
+      await seedProblemWithType({ title: '하노이의 탑', level: 3 });
+
+      // When
+      const res = await request(app.getHttpServer())
+        .get('/api/v2/problems')
+        .query({ title: '피보나치' })
+        .expect(200);
+
+      // Then
+      expect(res.body.statusCode).toBe(200);
+      expect(res.body.data.problemList).toBeInstanceOf(Array);
+    });
+
+    it('title 검색 — 빈 문자열이면 200과 전체 목록을 반환한다', async () => {
+      // Given
+      await seedProblemWithType({ title: '문제 가' });
+      await seedProblemWithType({ title: '문제 나' });
+
+      // When
+      const res = await request(app.getHttpServer())
+        .get('/api/v2/problems')
+        .query({ title: '' })
+        .expect(200);
+
+      // Then
+      expect(res.body.statusCode).toBe(200);
+      expect(res.body.data.problemList.length).toBe(2);
+    });
+
+    it('levelList 필터 — 해당 레벨 문제만 반환한다', async () => {
+      // Given
+      await seedProblemWithType({ title: '레벨1 문제', level: 1 });
+      await seedProblemWithType({ title: '레벨5 문제', level: 5 });
+      await seedProblemWithType({ title: '레벨10 문제', level: 10 });
+
+      // When
+      const res = await request(app.getHttpServer())
+        .get('/api/v2/problems')
+        .query({ 'levelList[]': [1, 5] })
+        .expect(200);
+
+      // Then
+      expect(res.body.statusCode).toBe(200);
+      const levels = res.body.data.problemList.map(
+        (p: { level: number }) => p.level,
+      );
+      for (const level of levels) {
+        expect([1, 5]).toContain(level);
+      }
+    });
+
+    it('typeList 잘못된 값 — 400 validation error', async () => {
+      // When
+      const res = await request(app.getHttpServer())
+        .get('/api/v2/problems')
+        .query({ 'typeList[]': ['없는유형'] })
+        .expect(400);
+
+      // Then
+      expect(res.body.statusCode).toBe(400);
+      expect(res.body.errorMessage).toContain('올바른 문제 유형이 아닙니다');
+    });
+
+    it('sort 유효한 enum — 200을 반환한다', async () => {
+      // Given
+      await seedProblemWithType({ title: '문제 A', level: 1 });
+
+      // When — sort=10 (TITLE_ASC)
+      const res = await request(app.getHttpServer())
+        .get('/api/v2/problems')
+        .query({ sort: 10 })
+        .expect(200);
+
+      // Then
+      expect(res.body.statusCode).toBe(200);
+    });
+
+    it('sort 잘못된 값 — 400 validation error', async () => {
+      // When
+      const res = await request(app.getHttpServer())
+        .get('/api/v2/problems')
+        .query({ sort: 999 })
+        .expect(400);
+
+      // Then
+      expect(res.body.statusCode).toBe(400);
+      expect(res.body.errorMessage).toContain('올바른 정렬 방식이 아닙니다');
+    });
+
+    it('로그인 유저 — state가 매핑된다', async () => {
+      // Given
+      const user = await seedTestUser(prisma);
+      const problem = await seedProblemWithType({
+        title: '상태 문제',
+        level: 1,
+      });
+      await seedUserProblemState(user.uuid, problem.uuid, 'SOLVED');
+      const accessToken = await getAccessToken(app, {
+        sub: user.uuid,
+        roles: [],
+      });
+
+      // When
+      const res = await request(app.getHttpServer())
+        .get('/api/v2/problems')
+        .set(createAuthHeaders(accessToken))
+        .expect(200);
+
+      // Then
+      const found = res.body.data.problemList.find(
+        (p: { uuid: string }) => p.uuid === problem.uuid,
+      );
+      expect(found).toBeDefined();
+      expect(found.state).toBe('SOLVED');
+    });
+
+    it('비로그인 유저 — state가 전부 NONE이다', async () => {
+      // Given
+      await seedProblemWithType({ title: '문제 A', level: 1 });
+      await seedProblemWithType({ title: '문제 B', level: 2 });
+
+      // When
+      const res = await request(app.getHttpServer())
+        .get('/api/v2/problems')
+        .expect(200);
+
+      // Then
+      for (const problem of res.body.data.problemList) {
+        expect(problem.state).toBe('NONE');
+      }
+    });
+
+    it('결과 0건인 검색 조건 — 200과 빈 배열을 반환한다', async () => {
+      // Given
+      await seedProblemWithType({ title: '문제 A', level: 1 });
+
+      // When
+      const res = await request(app.getHttpServer())
+        .get('/api/v2/problems')
+        .query({ 'levelList[]': [99] })
+        .expect(200);
+
+      // Then
+      expect(res.body.statusCode).toBe(200);
+      expect(res.body.data.problemList).toEqual([]);
+      expect(res.body.data.totalCount).toBe(0);
+    });
+  });
+
+  // ─── GET /api/v2/problems/today (오늘의 문제) ────────────────
+
+  describe('GET /api/v2/problems/today', () => {
+    it('day=0 (오늘) — 200을 반환한다', async () => {
+      // Given
+      const problem = await seedProblemWithType({
+        title: '오늘의 문제',
+        level: 3,
+      });
+      const today = new Date();
+      today.setHours(12, 0, 0, 0);
+      await seedTodayProblem(problem.uuid, today);
+
+      // When
+      const res = await request(app.getHttpServer())
+        .get('/api/v2/problems/today')
+        .query({ day: 0 })
+        .expect(200);
+
+      // Then
+      expect(res.body.statusCode).toBe(200);
+      expect(res.body.data).toBeInstanceOf(Array);
+      expect(res.body.data.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('day=-1 (어제) — 200을 반환한다', async () => {
+      // Given
+      const problem = await seedProblemWithType({
+        title: '어제의 문제',
+        level: 2,
+      });
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+      yesterday.setHours(12, 0, 0, 0);
+      await seedTodayProblem(problem.uuid, yesterday);
+
+      // When
+      const res = await request(app.getHttpServer())
+        .get('/api/v2/problems/today')
+        .query({ day: -1 })
+        .expect(200);
+
+      // Then
+      expect(res.body.statusCode).toBe(200);
+      expect(res.body.data).toBeInstanceOf(Array);
+      expect(res.body.data.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('day=-30 — 200을 반환한다', async () => {
+      // Given
+      const problem = await seedProblemWithType({
+        title: '30일 전 문제',
+        level: 4,
+      });
+      const thirtyDaysAgo = new Date();
+      thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+      thirtyDaysAgo.setHours(12, 0, 0, 0);
+      await seedTodayProblem(problem.uuid, thirtyDaysAgo);
+
+      // When
+      const res = await request(app.getHttpServer())
+        .get('/api/v2/problems/today')
+        .query({ day: -30 })
+        .expect(200);
+
+      // Then
+      expect(res.body.statusCode).toBe(200);
+      expect(res.body.data).toBeInstanceOf(Array);
+    });
+
+    it('day=-31 — 400 "30일 전까지만 조회 가능합니다."', async () => {
+      // When
+      const res = await request(app.getHttpServer())
+        .get('/api/v2/problems/today')
+        .query({ day: -31 })
+        .expect(400);
+
+      // Then
+      expect(res.body.statusCode).toBe(400);
+      expect(res.body.errorMessage).toContain('30일 전까지만 조회 가능합니다.');
+    });
+
+    it('day=1 — 400 "과거 날짜만 조회 가능합니다."', async () => {
+      // When
+      const res = await request(app.getHttpServer())
+        .get('/api/v2/problems/today')
+        .query({ day: 1 })
+        .expect(400);
+
+      // Then
+      expect(res.body.statusCode).toBe(400);
+      expect(res.body.errorMessage).toContain('과거 날짜만 조회 가능합니다.');
+    });
+
+    it('day 미지정 — 200 (기본값 0)', async () => {
+      // Given
+      const problem = await seedProblemWithType({
+        title: '기본 오늘의 문제',
+        level: 1,
+      });
+      const today = new Date();
+      today.setHours(12, 0, 0, 0);
+      await seedTodayProblem(problem.uuid, today);
+
+      // When
+      const res = await request(app.getHttpServer())
+        .get('/api/v2/problems/today')
+        .expect(200);
+
+      // Then
+      expect(res.body.statusCode).toBe(200);
+      expect(res.body.data).toBeInstanceOf(Array);
+    });
+
+    it('day=문자열 — 400 "날짜는 숫자만 입력할 수 있습니다."', async () => {
+      // When
+      const res = await request(app.getHttpServer())
+        .get('/api/v2/problems/today')
+        .query({ day: 'abc' })
+        .expect(400);
+
+      // Then
+      expect(res.body.statusCode).toBe(400);
+      expect(res.body.errorMessage).toContain(
+        '날짜는 숫자만 입력할 수 있습니다.',
+      );
+    });
+
+    it('해당 날짜에 문제 없음 — 200과 빈 배열을 반환한다', async () => {
+      // When — 시드 없이 조회
+      const res = await request(app.getHttpServer())
+        .get('/api/v2/problems/today')
+        .query({ day: -5 })
+        .expect(200);
+
+      // Then
+      expect(res.body.statusCode).toBe(200);
+      expect(res.body.data).toEqual([]);
+    });
+
+    it('로그인/비로그인 state 매핑을 확인한다', async () => {
+      // Given
+      const user = await seedTestUser(prisma);
+      const problem = await seedProblemWithType({
+        title: '상태 확인 문제',
+        level: 3,
+      });
+      const today = new Date();
+      today.setHours(12, 0, 0, 0);
+      await seedTodayProblem(problem.uuid, today);
+      await seedUserProblemState(user.uuid, problem.uuid, 'SOLVED');
+      const accessToken = await getAccessToken(app, {
+        sub: user.uuid,
+        roles: [],
+      });
+
+      // When — 로그인 유저
+      const loggedInRes = await request(app.getHttpServer())
+        .get('/api/v2/problems/today')
+        .query({ day: 0 })
+        .set(createAuthHeaders(accessToken))
+        .expect(200);
+
+      // Then — 로그인 유저는 state가 SOLVED
+      const loggedInProblem = loggedInRes.body.data.find(
+        (p: { uuid: string }) => p.uuid === problem.uuid,
+      );
+      expect(loggedInProblem).toBeDefined();
+      expect(loggedInProblem.state).toBe('SOLVED');
+
+      // When — 비로그인 유저
+      const guestRes = await request(app.getHttpServer())
+        .get('/api/v2/problems/today')
+        .query({ day: 0 })
+        .expect(200);
+
+      // Then — 비로그인 유저는 state가 NONE
+      const guestProblem = guestRes.body.data.find(
+        (p: { uuid: string }) => p.uuid === problem.uuid,
+      );
+      expect(guestProblem).toBeDefined();
+      expect(guestProblem.state).toBe('NONE');
+    });
+  });
+
+  // ─── GET /api/v2/problems/:problemUuid (상세) ────────────────
+
+  describe('GET /api/v2/problems/:problemUuid', () => {
+    it('존재하는 UUID — 200과 상세 정보를 반환한다', async () => {
+      // Given
+      const problem = await seedProblemWithType(
+        { title: '상세 문제', level: 5 },
+        ['수학', '구현'],
+      );
+      // inputOutput 시드
+      await prisma.problemV2InputOutput.create({
+        data: {
+          order: 1,
+          input: '1 2',
+          output: '3',
+          problemUuid: problem.uuid,
+        },
+      });
+
+      // When
+      const res = await request(app.getHttpServer())
+        .get(`/api/v2/problems/${problem.uuid}`)
+        .expect(200);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 200,
+        errorCode: '0000',
+        errorMessage: '',
+      });
+      expect(res.body.data).toMatchObject({
+        uuid: problem.uuid,
+        title: '상세 문제',
+        level: 5,
+      });
+      expect(res.body.data.inputOutputList).toBeInstanceOf(Array);
+      expect(res.body.data.inputOutputList.length).toBe(1);
+      expect(res.body.data.typeList).toEqual(
+        expect.arrayContaining(['수학', '구현']),
+      );
+      expect(res.body.data.subTaskList).toBeInstanceOf(Array);
+    });
+
+    it('존재하지 않는 UUID — 404 PROBLEM_NOT_FOUND', async () => {
+      // Given
+      const nonExistentUuid = '00000000-0000-0000-0000-000000000000';
+
+      // When
+      const res = await request(app.getHttpServer())
+        .get(`/api/v2/problems/${nonExistentUuid}`)
+        .expect(404);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 404,
+        errorCode: 'PROBLEM_NOT_FOUND',
+      });
+    });
+
+    it('로그인 유저 — state가 매핑된다', async () => {
+      // Given
+      const user = await seedTestUser(prisma);
+      const problem = await seedProblemWithType({
+        title: '로그인 상세 문제',
+        level: 3,
+      });
+      await seedUserProblemState(user.uuid, problem.uuid, 'FAILED');
+      const accessToken = await getAccessToken(app, {
+        sub: user.uuid,
+        roles: [],
+      });
+
+      // When
+      const res = await request(app.getHttpServer())
+        .get(`/api/v2/problems/${problem.uuid}`)
+        .set(createAuthHeaders(accessToken))
+        .expect(200);
+
+      // Then
+      expect(res.body.data.state).toBe('FAILED');
+    });
+
+    it('비로그인 유저 — state=NONE', async () => {
+      // Given
+      const problem = await seedProblemWithType({
+        title: '비로그인 상세 문제',
+        level: 2,
+      });
+
+      // When
+      const res = await request(app.getHttpServer())
+        .get(`/api/v2/problems/${problem.uuid}`)
+        .expect(200);
+
+      // Then
+      expect(res.body.data.state).toBe('NONE');
+    });
+  });
+});

--- a/test/users.e2e-spec.ts
+++ b/test/users.e2e-spec.ts
@@ -1,0 +1,148 @@
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { createTestApp, closeTestApp } from './helpers/setup';
+import { getAccessToken, createAuthHeaders } from './helpers/auth';
+import { seedTestUser, cleanDatabase } from './helpers/seed';
+import { PrismaService } from '../src/prisma/prisma.service';
+
+describe('Users E2E', () => {
+  let app: INestApplication;
+  let prisma: PrismaService;
+
+  beforeAll(async () => {
+    const { app: testApp } = await createTestApp();
+    app = testApp;
+    prisma = app.get(PrismaService);
+  });
+
+  afterAll(async () => {
+    await closeTestApp(app);
+  });
+
+  afterEach(async () => {
+    await cleanDatabase(prisma);
+  });
+
+  describe('GET /users/:uuid', () => {
+    it('존재하는 유저 UUID 로 200과 유저 정보를 반환한다', async () => {
+      // Given
+      const caller = await seedTestUser(prisma);
+      const target = await seedTestUser(prisma, {
+        name: 'target-user',
+        email: 'target@test.com',
+      });
+      const accessToken = await getAccessToken(app, {
+        sub: caller.uuid,
+        roles: [],
+      });
+
+      // When
+      const res = await request(app.getHttpServer())
+        .get(`/users/${target.uuid}`)
+        .set(createAuthHeaders(accessToken))
+        .expect(200);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 200,
+        errorCode: '0000',
+        errorMessage: '',
+      });
+      expect(res.body.data).toMatchObject({
+        uuid: target.uuid,
+        name: 'target-user',
+        email: 'target@test.com',
+        profilePhoto: '',
+      });
+    });
+
+    it('존재하지 않는 UUID 이면 404 USER_NOT_FOUND 를 반환한다', async () => {
+      // Given
+      const caller = await seedTestUser(prisma);
+      const accessToken = await getAccessToken(app, {
+        sub: caller.uuid,
+        roles: [],
+      });
+      const nonExistentUuid = '00000000-0000-0000-0000-000000000000';
+
+      // When
+      const res = await request(app.getHttpServer())
+        .get(`/users/${nonExistentUuid}`)
+        .set(createAuthHeaders(accessToken))
+        .expect(404);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 404,
+        errorCode: 'USER_NOT_FOUND',
+      });
+    });
+
+    it('잘못된 형식의 UUID 이면 404 USER_NOT_FOUND 를 반환한다', async () => {
+      // Given
+      const caller = await seedTestUser(prisma);
+      const accessToken = await getAccessToken(app, {
+        sub: caller.uuid,
+        roles: [],
+      });
+
+      // When
+      const res = await request(app.getHttpServer())
+        .get('/users/not-a-valid-uuid')
+        .set(createAuthHeaders(accessToken))
+        .expect(404);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 404,
+        errorCode: 'USER_NOT_FOUND',
+      });
+    });
+
+    it('토큰이 없으면 401 JWT_MISSING 을 반환한다', async () => {
+      // Given
+      const target = await seedTestUser(prisma);
+
+      // When
+      const res = await request(app.getHttpServer())
+        .get(`/users/${target.uuid}`)
+        .expect(401);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 401,
+        errorCode: 'JWT_MISSING',
+      });
+    });
+
+    it('비활성 유저를 조회해도 200 을 반환한다', async () => {
+      // Given
+      const caller = await seedTestUser(prisma);
+      const inactiveUser = await seedTestUser(prisma, {
+        state: 'INACTIVE',
+        name: 'inactive-user',
+      });
+      const accessToken = await getAccessToken(app, {
+        sub: caller.uuid,
+        roles: [],
+      });
+
+      // When
+      const res = await request(app.getHttpServer())
+        .get(`/users/${inactiveUser.uuid}`)
+        .set(createAuthHeaders(accessToken))
+        .expect(200);
+
+      // Then
+      expect(res.body).toMatchObject({
+        statusCode: 200,
+        errorCode: '0000',
+        errorMessage: '',
+      });
+      expect(res.body.data).toMatchObject({
+        uuid: inactiveUser.uuid,
+        name: 'inactive-user',
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 포함된 변경 사항

### E2E 테스트 환경 구축 및 전체 테스트 작성 (ALGOGO-55 ~ ALGOGO-62)
- [x] E2E 테스트 인프라 구축 — 헬퍼(setup, auth, seed), jest-e2e 설정, .test.env
- [x] Auth E2E 테스트 (refresh, logout — 14개 시나리오)
- [x] OAuth E2E 테스트 (login/register, connect, disconnect — 13개 시나리오)
- [x] 유저 API E2E 테스트 (me, users — 13개 시나리오)
- [x] 문제 API E2E 테스트 (목록, 오늘의 문제, 상세 — 31개 시나리오)
- [x] 코드 API E2E 테스트 (setting, template CRUD, problem code — 22개 시나리오)
- [x] 문제 사이트 연동 E2E 테스트 (create, delete — 12개 시나리오)
- [x] WebSocket 코드 실행 E2E 테스트 (auth, execute — 6개 시나리오)

### 보안 (ALGOGO-63, ALGOGO-69)
- [x] 1차: multer, axios, socket.io, fast-xml-parser, bcrypt→bcryptjs, flatted
- [x] 2차: form-data, validator, minimatch, jws, qs, js-yaml, @smithy/config-resolver

### 정리 (ALGOGO-64)
- [x] .gitignore에 .claude/worktrees/ 추가

## 이슈
- ALGOGO-55 ~ ALGOGO-64, ALGOGO-69